### PR TITLE
feat: symlink support for documents directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-![Version](https://img.shields.io/badge/version-3.2.3-blue.svg)
+![Version](https://img.shields.io/badge/version-3.2.4-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12-green.svg)
 ![License](https://img.shields.io/badge/license-MIT-yellow.svg)
 ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-lightgrey.svg)
@@ -996,6 +996,12 @@ With ~200 documents, expect ~300-500MB RAM. The embedding model (~50MB) and rera
 ---
 
 ## Changelog
+
+### v3.2.4 (2026-04-03)
+
+- **NEW**: Symlink support — `documents/` directory now follows symbolic links recursively ([#13](https://github.com/lyonzin/knowledge-rag/issues/13))
+- **NEW**: Circular symlink loop protection via realpath deduplication
+- **IMPROVED**: `_has_documents()` detection now validates against supported formats only (stricter than before)
 
 ### v3.2.3 (2026-03-22)
 

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -12,12 +12,19 @@ from typing import Dict, List
 _source_dir = Path(__file__).parent.parent
 
 
+_SUPPORTED_SUFFIXES = frozenset([".md", ".txt", ".pdf", ".py", ".json", ".docx", ".xlsx", ".pptx", ".csv"])
+
+
 def _has_documents(path: Path) -> bool:
-    """Check if path has a documents/ dir with actual files (not just empty dirs)."""
+    """Check if path has a documents/ dir with actual supported files (follows symlinks)."""
     docs_dir = path / "documents"
     if not docs_dir.exists():
         return False
-    return any(docs_dir.rglob("*.*"))
+    for root, _, files in os.walk(docs_dir, followlinks=True):
+        for f in files:
+            if Path(f).suffix.lower() in _SUPPORTED_SUFFIXES:
+                return True
+    return False
 
 
 if os.environ.get("KNOWLEDGE_RAG_DIR"):

--- a/mcp_server/ingestion.py
+++ b/mcp_server/ingestion.py
@@ -6,6 +6,7 @@ Supports: MD, PDF, TXT, PY, JSON, DOCX, XLSX, PPTX, CSV
 
 import hashlib
 import json
+import os
 import re
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -150,12 +151,23 @@ class DocumentParser:
         return doc
 
     def parse_directory(self, directory: Path = None) -> List[Document]:
-        """Parse all supported files in a directory recursively"""
+        """Parse all supported files in a directory recursively (follows symlinks)."""
         directory = Path(directory) if directory else config.documents_dir
         documents = []
+        seen_dirs = set()
+        supported = set(config.supported_formats)
 
-        for ext in config.supported_formats:
-            for filepath in directory.rglob(f"*{ext}"):
+        for root, dirs, files in os.walk(directory, followlinks=True):
+            real_root = os.path.realpath(root)
+            if real_root in seen_dirs:
+                dirs.clear()
+                continue
+            seen_dirs.add(real_root)
+
+            for fname in files:
+                filepath = Path(root) / fname
+                if filepath.suffix.lower() not in supported:
+                    continue
                 try:
                     doc = self.parse_file(filepath)
                     if doc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "knowledge-rag"
-version = "3.2.3"
+version = "3.2.4"
 description = "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 12 MCP Tools. Zero external servers."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- `parse_directory()` now follows symbolic links via `os.walk(followlinks=True)`
- Circular symlink loop protection via `realpath` deduplication (prevents infinite recursion)
- `_has_documents()` detection now validates against `supported_formats` only (stricter — ignores `.gitkeep`, temp files, etc.)

Closes #13

## Changes

| File | What |
|------|------|
| `mcp_server/config.py` | `_has_documents()` → `os.walk` + format validation |
| `mcp_server/ingestion.py` | `parse_directory()` → `os.walk` + `seen_dirs` loop protection |
| `pyproject.toml` | Version bump → 3.2.4 |
| `README.md` | Changelog + version badge |

## Test plan

- [x] All 55 existing tests pass
- [ ] Manual test with symlinked documents directory
- [ ] Manual test with circular symlinks (should skip, not crash)