### PR TITLE
feat: NPM wrapper + Trusted Publishing + Docker GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,24 +5,27 @@ on:
     types: [published]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   test:
     name: Pre-release Tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
       - run: |
           pip install -r requirements.txt
           pip install pytest
           pytest tests/ -v
 
-  publish-pypi:
-    name: Publish to PyPI
+  build:
+    name: Build Distribution
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -32,21 +35,84 @@ jobs:
           python-version: "3.12"
       - run: pip install build
       - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: actions/upload-artifact@v4
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          name: python-dist
+          path: dist/
+          retention-days: 5
 
-  docker:
-    name: Build Docker Image
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-npm:
+    name: Publish to NPM
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - name: Sync version from release tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          cd npm
+          node -e "
+            const pkg = require('./package.json');
+            pkg.version = '${VERSION}';
+            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+      - name: Copy LICENSE
+        run: cp LICENSE npm/LICENSE
+      - name: Publish to NPM
+        working-directory: npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-docker:
+    name: Push Docker Image
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/lyonzin/knowledge-rag
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
       - uses: docker/build-push-action@v7
         with:
           context: .
-          push: false
-          tags: lyonzin/knowledge-rag:${{ github.event.release.tag_name }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/npm/.npmignore
+++ b/npm/.npmignore
@@ -1,0 +1,6 @@
+*
+!bin/
+!bin/**
+!README.md
+!LICENSE
+!package.json

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,61 @@
+[![npm version](https://img.shields.io/npm/v/knowledge-rag.svg)](https://www.npmjs.com/package/knowledge-rag)
+
+# Knowledge RAG
+
+Local RAG system for Claude Code. Hybrid BM25 + semantic search with cross-encoder reranking. 12 MCP tools. Zero external servers. Everything runs on your machine.
+
+## Quick Start
+
+```bash
+npx knowledge-rag
+```
+
+The wrapper handles Python venv creation, package installation, and server startup automatically.
+
+## Claude Code Configuration
+
+Add to your MCP settings (`~/.claude.json` or project `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "knowledge-rag": {
+      "command": "npx",
+      "args": ["-y", "knowledge-rag"]
+    }
+  }
+}
+```
+
+## CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `--version` | Print version and exit |
+| `--install-only` | Install the Python package into the venv without starting the server |
+
+## Requirements
+
+- **Node.js** >= 16
+- **Python** >= 3.11
+
+The wrapper auto-detects your Python installation across platforms (Windows: `python`, `py -3`; Linux/macOS: `python3`, `python`).
+
+## How It Works
+
+1. Finds a compatible Python 3.11+ interpreter on your system
+2. Creates a persistent virtual environment at `~/.knowledge-rag/venv`
+3. Installs the `knowledge-rag` PyPI package (skips if already up to date)
+4. Starts the MCP server over stdio
+
+The venv and installed package persist between runs. Reinstallation only happens when the NPM package version changes.
+
+## Full Documentation
+
+See the main repository for complete docs, configuration options, and tool reference:
+
+**https://github.com/lyonzin/knowledge-rag**
+
+## License
+
+MIT

--- a/npm/bin/cli.js
+++ b/npm/bin/cli.js
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const { execFileSync, spawn } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PACKAGE_VERSION = require("../package.json").version;
+const BASE_DIR = path.join(os.homedir(), ".knowledge-rag");
+const VENV_DIR = path.join(BASE_DIR, "venv");
+const VERSION_FILE = path.join(BASE_DIR, ".npm-version");
+const PYPI_PACKAGE = "knowledge-rag";
+const MIN_PYTHON_MAJOR = 3;
+const MIN_PYTHON_MINOR = 11;
+
+// ---------------------------------------------------------------------------
+// Helpers — all user-facing output goes to STDERR (MCP uses stdout)
+// ---------------------------------------------------------------------------
+
+function log(msg) {
+  process.stderr.write(`[knowledge-rag] ${msg}\n`);
+}
+
+function fatal(msg) {
+  process.stderr.write(`[knowledge-rag] ERROR: ${msg}\n`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Python discovery (cross-platform)
+// ---------------------------------------------------------------------------
+
+function tryPython(cmd, args) {
+  try {
+    const out = execFileSync(cmd, args, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 10000,
+    }).trim();
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+function parsePythonVersion(versionStr) {
+  const match = versionStr && versionStr.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return {
+    major: parseInt(match[1], 10),
+    minor: parseInt(match[2], 10),
+    patch: parseInt(match[3], 10),
+    raw: match[0],
+  };
+}
+
+function findPython() {
+  const isWindows = process.platform === "win32";
+
+  const candidates = isWindows
+    ? [
+        { cmd: "python", args: ["--version"] },
+        { cmd: "py", args: ["-3", "--version"] },
+      ]
+    : [
+        { cmd: "python3", args: ["--version"] },
+        { cmd: "python", args: ["--version"] },
+      ];
+
+  for (const { cmd, args } of candidates) {
+    const raw = tryPython(cmd, args);
+    const ver = parsePythonVersion(raw);
+    if (!ver) continue;
+    if (ver.major < MIN_PYTHON_MAJOR) continue;
+    if (ver.major === MIN_PYTHON_MAJOR && ver.minor < MIN_PYTHON_MINOR) continue;
+
+    const execCmd = cmd === "py" ? "py" : cmd;
+    const execArgs = cmd === "py" ? ["-3"] : [];
+    return { cmd: execCmd, args: execArgs, version: ver };
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Venv management
+// ---------------------------------------------------------------------------
+
+function getVenvPython() {
+  if (process.platform === "win32") {
+    return path.join(VENV_DIR, "Scripts", "python.exe");
+  }
+  return path.join(VENV_DIR, "bin", "python");
+}
+
+function venvExists() {
+  return fs.existsSync(getVenvPython());
+}
+
+function createVenv(python) {
+  log(`Creating virtual environment at ${VENV_DIR}`);
+  fs.mkdirSync(BASE_DIR, { recursive: true });
+
+  const args = [...python.args, "-m", "venv", VENV_DIR];
+  try {
+    execFileSync(python.cmd, args, {
+      stdio: ["ignore", "ignore", "pipe"],
+      timeout: 120000,
+    });
+  } catch (err) {
+    fatal(
+      `Failed to create virtual environment.\n` +
+        `  Command: ${python.cmd} ${args.join(" ")}\n` +
+        `  ${err.stderr ? err.stderr.toString().trim() : err.message}`
+    );
+  }
+}
+
+function installedVersionMatches() {
+  try {
+    const stored = fs.readFileSync(VERSION_FILE, "utf-8").trim();
+    return stored === PACKAGE_VERSION;
+  } catch {
+    return false;
+  }
+}
+
+function writeVersionFile() {
+  fs.writeFileSync(VERSION_FILE, PACKAGE_VERSION, "utf-8");
+}
+
+function installPackage() {
+  const venvPython = getVenvPython();
+  log(`Installing ${PYPI_PACKAGE}==${PACKAGE_VERSION} from PyPI`);
+
+  const args = [
+    "-m",
+    "pip",
+    "install",
+    "--upgrade",
+    "--quiet",
+    `${PYPI_PACKAGE}==${PACKAGE_VERSION}`,
+  ];
+
+  try {
+    execFileSync(venvPython, args, {
+      stdio: ["ignore", "ignore", "pipe"],
+      timeout: 300000,
+    });
+  } catch (err) {
+    fatal(
+      `Failed to install ${PYPI_PACKAGE}.\n` +
+        `  ${err.stderr ? err.stderr.toString().trim() : err.message}`
+    );
+  }
+
+  writeVersionFile();
+  log("Installation complete");
+}
+
+// ---------------------------------------------------------------------------
+// Ensure environment is ready
+// ---------------------------------------------------------------------------
+
+function ensureInstalled(python) {
+  if (!venvExists()) {
+    createVenv(python);
+    installPackage();
+    return;
+  }
+
+  if (!installedVersionMatches()) {
+    log("Version changed, updating package");
+    installPackage();
+    return;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run the MCP server
+// ---------------------------------------------------------------------------
+
+function runServer() {
+  const venvPython = getVenvPython();
+
+  const child = spawn(venvPython, ["-m", "mcp_server.server"], {
+    stdio: "inherit",
+    windowsHide: true,
+  });
+
+  const forwardSignal = (sig) => {
+    if (child.pid) {
+      try {
+        child.kill(sig);
+      } catch {
+        // child may have already exited
+      }
+    }
+  };
+
+  process.on("SIGINT", () => forwardSignal("SIGINT"));
+  process.on("SIGTERM", () => forwardSignal("SIGTERM"));
+
+  child.on("error", (err) => {
+    fatal(`Failed to start MCP server: ${err.message}`);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.exit(1);
+    }
+    process.exit(code || 0);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--version")) {
+    process.stderr.write(`knowledge-rag ${PACKAGE_VERSION}\n`);
+    process.exit(0);
+  }
+
+  const python = findPython();
+  if (!python) {
+    fatal(
+      `Python ${MIN_PYTHON_MAJOR}.${MIN_PYTHON_MINOR}+ is required but was not found.\n` +
+        `  Searched for: ${process.platform === "win32" ? "python, py -3" : "python3, python"}\n` +
+        `  Install Python from https://www.python.org/downloads/`
+    );
+  }
+
+  log(`Found Python ${python.version.raw}`);
+  ensureInstalled(python);
+
+  if (args.includes("--install-only")) {
+    log("Install complete (--install-only). Exiting.");
+    process.exit(0);
+  }
+
+  runServer();
+}
+
+main();

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "knowledge-rag",
+  "version": "3.5.2",
+  "description": "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 12 MCP Tools. Zero external servers.",
+  "bin": {
+    "knowledge-rag": "./bin/cli.js"
+  },
+  "keywords": [
+    "rag",
+    "mcp",
+    "claude-code",
+    "semantic-search",
+    "embeddings",
+    "knowledge-base",
+    "local-ai",
+    "retrieval-augmented-generation",
+    "hybrid-search",
+    "claude"
+  ],
+  "author": "Lyon. <lyonzin@users.noreply.github.com>",
+  "license": "MIT",
+  "homepage": "https://github.com/lyonzin/knowledge-rag",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lyonzin/knowledge-rag.git",
+    "directory": "npm"
+  },
+  "bugs": {
+    "url": "https://github.com/lyonzin/knowledge-rag/issues"
+  },
+  "engines": {
+    "node": ">=16"
+  },
+  "files": [
+    "bin/",
+    "README.md",
+    "LICENSE"
+  ]
+}


### PR DESCRIPTION
## Summary

- **NPM wrapper** (`npm/`) — enables `npx knowledge-rag` for zero-config installation
- **Fixed release pipeline** — migrated from broken API token to Trusted Publishing (OIDC)
- **Added NPM auto-publish** — version syncs from git tag automatically
- **Added Docker GHCR push** — `ghcr.io/lyonzin/knowledge-rag:latest`

## NPM Wrapper Details

The wrapper is a thin Node.js CLI that:
1. Auto-detects Python 3.11+ (cross-platform: Windows `python`/`py -3`, Unix `python3`/`python`)
2. Creates persistent venv at `~/.knowledge-rag/venv`
3. Installs exact PyPI version (pinned to NPM package version)
4. Runs MCP server with stdio inherited
5. All wrapper output to stderr (MCP protocol compatibility)
6. Signal forwarding (SIGINT/SIGTERM) for clean shutdown
7. Smart reinstall — only when NPM version changes

Zero external dependencies. Pure Node.js stdlib.

## Release Pipeline Changes

| Before | After |
|--------|-------|
| `PYPI_API_TOKEN` secret (broken) | Trusted Publishing OIDC (no secrets) |
| Single test matrix | Multi-Python (3.11, 3.12) |
| No artifact separation | Build once, publish once |
| Docker build only | Docker push to GHCR |
| PyPI only | PyPI + NPM + Docker |

## Manual Steps Required (before merging)

1. **PyPI Trusted Publisher** — configure on pypi.org/manage/project/knowledge-rag/settings/publishing/
2. **GitHub Environment** — create `release` environment in repo settings
3. **NPM Token** — add `NPM_TOKEN` secret to `release` environment

See PR comments for detailed instructions.

## Files Changed

- `.github/workflows/release.yml` — complete rewrite
- `npm/package.json` — NPM package metadata
- `npm/bin/cli.js` — CLI wrapper (266 lines, zero deps)
- `npm/README.md` — NPM-specific docs
- `npm/.npmignore` — whitelist-only publish filter