### PR TITLE
Add ChromaDB startup preflight and offline reranker fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,7 +772,7 @@ models:
     dimensions: 384
     gpu: false                         # Set true + pip install knowledge-rag[gpu]
   reranker:
-    enabled: true                      # Set false on low-resource machines
+    enabled: true                      # Falls back to RRF if model is unavailable
     model: "Xenova/ms-marco-MiniLM-L-6-v2"
     top_k_multiplier: 3               # Candidates fetched before reranking
 
@@ -858,6 +858,8 @@ For `.md` files, chunking splits at `##` and `###` header boundaries first. Sect
 | `models.reranker.enabled` | true | Enable cross-encoder reranking |
 | `models.reranker.model` | `Xenova/ms-marco-MiniLM-L-6-v2` | Reranker model |
 | `models.reranker.top_k_multiplier` | 3 | Fetch N*multiplier candidates for reranking |
+
+If the reranker model is not available locally and the machine cannot download it, search now falls back to the RRF order from hybrid semantic+BM25 retrieval. This keeps `search_knowledge` available offline, but result ordering may be less precise for ambiguous queries until the reranker model is cached.
 
 **Embedding model options** (fastest → most accurate):
 - `BAAI/bge-small-en-v1.5` — 384D, ~33MB (default)
@@ -989,6 +991,31 @@ rm -rf models_cache
 # Then restart the MCP server
 ```
 
+### Reranker model download fails
+
+The reranker is lazy-loaded on the first query. If the model is not cached and the machine is offline, search continues without reranking and uses the RRF order from hybrid retrieval. To keep reranking enabled offline, run one query while online or pre-populate `models_cache/` on the target machine.
+
+You can still disable reranking explicitly in `config.yaml`:
+
+```yaml
+models:
+  reranker:
+    enabled: false
+```
+
+Disabling reranking reduces memory use and avoids first-query model loading. The tradeoff is lower ranking precision, especially when several chunks match the same terms but only one is the best answer.
+
+### ChromaDB index crashes on startup
+
+Native ChromaDB failures can terminate Python before normal exception handling runs. Startup now probes ChromaDB in a child process before initializing the MCP server. If the probe crashes, the active `chroma_db/` and `index_metadata.json` are moved to `data/backups/auto-repair-*`, and the next startup can rebuild a clean index.
+
+The same guarded behavior is available through either console script:
+
+```bash
+knowledge-rag
+knowledge-rag-guarded
+```
+
 ### Index is empty
 
 ```bash
@@ -1019,7 +1046,7 @@ pip install --upgrade knowledge-rag
 
 ### Slow first query
 
-The cross-encoder reranker model is lazy-loaded on the first query. This adds a one-time ~2-3 second delay for model download and loading. Subsequent queries are fast.
+The cross-encoder reranker model is lazy-loaded on the first query. This adds a one-time ~2-3 second delay for model download and loading. Subsequent queries are fast. If the model cannot be loaded, search falls back to RRF ordering and does not retry loading the reranker until the server restarts.
 
 ### Memory usage
 
@@ -1028,6 +1055,13 @@ With ~200 documents, expect ~300-500MB RAM. The embedding model (~50MB) and rera
 ---
 
 ## Changelog
+
+### Unreleased
+
+- **FIX**: Startup preflight probes ChromaDB in a child process and moves crashing persistent indexes to `data/backups/auto-repair-*` before MCP initialization.
+- **FIX**: Reranker load failures now fall back to RRF ordering instead of failing `search_knowledge` on offline machines.
+- **FIX**: Virtualenv project-root detection now handles Python symlinks that resolve to the system interpreter.
+- **NEW**: `knowledge-rag-guarded` console script kept as an explicit guarded startup alias.
 
 ### v3.6.2 (2026-04-23)
 

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -54,10 +54,11 @@ def _has_documents(path: Path) -> bool:
 
 def _venv_project_dir():
     """Detect project root from venv location (pip install from PyPI)."""
-    exe = Path(sys.executable).resolve()
-    for parent in exe.parents:
-        if parent.name in ("venv", ".venv", "env", ".env"):
-            return parent.parent
+    candidates = [Path(sys.prefix), Path(sys.executable), Path(sys.executable).resolve()]
+    for candidate in candidates:
+        for parent in (candidate, *candidate.parents):
+            if parent.name in ("venv", ".venv", "env", ".env"):
+                return parent.parent
     return None
 
 

--- a/mcp_server/guarded.py
+++ b/mcp_server/guarded.py
@@ -1,0 +1,10 @@
+"""Backward-compatible guarded console entry point for knowledge-rag."""
+
+from __future__ import annotations
+
+from .server import main
+
+
+def guarded_main() -> None:
+    """Run the MCP server; server.main performs startup preflight."""
+    main()

--- a/mcp_server/preflight.py
+++ b/mcp_server/preflight.py
@@ -1,0 +1,75 @@
+"""Startup preflight checks for persistent ChromaDB state."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from .config import BASE_DIR, config
+
+
+def _backup_active_index(reason: str) -> Path:
+    """Move active ChromaDB state aside so the server can rebuild cleanly."""
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_dir = config.data_dir / "backups" / f"auto-repair-{stamp}"
+    backup_dir.mkdir(parents=True, exist_ok=False)
+
+    if config.chroma_dir.exists():
+        shutil.move(str(config.chroma_dir), str(backup_dir / f"chroma_db.{reason}"))
+
+    metadata_file = config.data_dir / "index_metadata.json"
+    if metadata_file.exists():
+        shutil.move(str(metadata_file), str(backup_dir / f"index_metadata.{reason}.json"))
+
+    return backup_dir
+
+
+def _probe_chroma(timeout_seconds: int = 30) -> subprocess.CompletedProcess[str]:
+    """Check Chroma in a child process so native crashes do not kill MCP startup."""
+    code = r"""
+import chromadb
+
+from mcp_server.config import config
+
+if not config.chroma_dir.exists():
+    print("missing")
+    raise SystemExit(0)
+
+client = chromadb.PersistentClient(path=str(config.chroma_dir))
+collection = client.get_or_create_collection(name=config.collection_name)
+print(collection.count())
+"""
+    env = os.environ.copy()
+    env.setdefault("KNOWLEDGE_RAG_DIR", str(BASE_DIR))
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(BASE_DIR),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout_seconds,
+        check=False,
+    )
+
+
+def run_preflight(timeout_seconds: int = 30) -> bool:
+    """Return True when active Chroma state was moved aside for repair."""
+    result = _probe_chroma(timeout_seconds=timeout_seconds)
+    if result.returncode == 0:
+        return False
+
+    reason = "segfault" if result.returncode in (-11, 139) else "failed"
+    backup_dir = _backup_active_index(reason)
+    print(
+        f"[RECOVERY] Chroma preflight failed with code {result.returncode}; "
+        f"moved active index to {backup_dir}",
+        file=sys.stderr,
+    )
+    if result.stderr:
+        print(result.stderr[-2000:], file=sys.stderr)
+    return True

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -248,13 +248,22 @@ class CrossEncoderReranker:
     def __init__(self, model: str = None):
         self.model_name = model or config.reranker_model
         self._model = None  # Lazy init
+        self._load_failed = False
 
-    def _ensure_model(self):
+    def _ensure_model(self) -> bool:
         """Lazy initialization of cross-encoder model"""
+        if self._load_failed:
+            return False
         if self._model is None:
             print(f"[INFO] Loading reranker model: {self.model_name}...")
-            self._model = TextCrossEncoder(model_name=self.model_name, cache_dir=str(config.models_cache_dir))
-            print("[INFO] Reranker model loaded successfully")
+            try:
+                self._model = TextCrossEncoder(model_name=self.model_name, cache_dir=str(config.models_cache_dir))
+                print("[INFO] Reranker model loaded successfully")
+            except Exception as e:
+                self._load_failed = True
+                print(f"[WARN] Reranker unavailable, using RRF order: {e}")
+                return False
+        return True
 
     def rerank(self, query: str, documents: List[Dict[str, Any]], top_k: int = 5) -> List[Dict[str, Any]]:
         """
@@ -271,7 +280,8 @@ class CrossEncoderReranker:
         if not documents or not config.reranker_enabled:
             return documents[:top_k]
 
-        self._ensure_model()
+        if not self._ensure_model():
+            return documents[:top_k]
 
         texts = [doc.get("document", "") for doc in documents]
 
@@ -1923,6 +1933,10 @@ def main():
     if len(sys.argv) > 1 and sys.argv[1] == "init":
         _handle_init()
         return
+
+    from .preflight import run_preflight
+
+    run_preflight()
 
     orchestrator = get_orchestrator()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ Changelog = "https://github.com/lyonzin/knowledge-rag/releases"
 
 [project.scripts]
 knowledge-rag = "mcp_server.server:main"
+knowledge-rag-guarded = "mcp_server.guarded:guarded_main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["mcp_server"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -74,6 +74,18 @@ def test_models_cache_dir_exists():
     assert config.models_cache_dir.exists()
 
 
+def test_venv_project_dir_uses_unresolved_executable(monkeypatch):
+    """Venv detection must survive python symlinks that resolve to system Python."""
+    from pathlib import Path
+
+    import mcp_server.config as config_module
+
+    monkeypatch.setattr(config_module.sys, "prefix", "/usr")
+    monkeypatch.setattr(config_module.sys, "executable", "/opt/knowledge-rag/venv/bin/python")
+
+    assert config_module._venv_project_dir() == Path("/opt/knowledge-rag")
+
+
 def test_exclude_patterns_default_empty():
     """Default exclude_patterns must be an empty list."""
     assert hasattr(config, "exclude_patterns")

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,49 @@
+"""Tests for startup preflight repair."""
+
+import subprocess
+
+
+def test_probe_failure_backs_up_chroma_and_metadata(tmp_path, monkeypatch):
+    """A crashing Chroma probe should move active state aside for rebuild."""
+    from mcp_server import preflight
+
+    data_dir = tmp_path / "data"
+    chroma_dir = data_dir / "chroma_db"
+    metadata_file = data_dir / "index_metadata.json"
+    chroma_dir.mkdir(parents=True)
+    (chroma_dir / "chroma.sqlite3").write_text("bad", encoding="utf-8")
+    metadata_file.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(preflight.config, "data_dir", data_dir)
+    monkeypatch.setattr(preflight.config, "chroma_dir", chroma_dir)
+
+    result = subprocess.CompletedProcess(args=[], returncode=-11, stdout="", stderr="segfault")
+    monkeypatch.setattr(preflight, "_probe_chroma", lambda timeout_seconds=30: result)
+
+    assert preflight.run_preflight() is True
+    assert not chroma_dir.exists()
+    assert not metadata_file.exists()
+
+    backups = list((data_dir / "backups").glob("auto-repair-*"))
+    assert len(backups) == 1
+    assert (backups[0] / "chroma_db.segfault").exists()
+    assert (backups[0] / "index_metadata.segfault.json").exists()
+
+
+def test_successful_probe_leaves_index_in_place(tmp_path, monkeypatch):
+    """A healthy Chroma probe should not move files."""
+    from mcp_server import preflight
+
+    data_dir = tmp_path / "data"
+    chroma_dir = data_dir / "chroma_db"
+    chroma_dir.mkdir(parents=True)
+    (chroma_dir / "chroma.sqlite3").write_text("ok", encoding="utf-8")
+
+    monkeypatch.setattr(preflight.config, "data_dir", data_dir)
+    monkeypatch.setattr(preflight.config, "chroma_dir", chroma_dir)
+
+    result = subprocess.CompletedProcess(args=[], returncode=0, stdout="1", stderr="")
+    monkeypatch.setattr(preflight, "_probe_chroma", lambda timeout_seconds=30: result)
+
+    assert preflight.run_preflight() is False
+    assert chroma_dir.exists()

--- a/tests/test_reranker_fallback.py
+++ b/tests/test_reranker_fallback.py
@@ -1,0 +1,36 @@
+"""Tests for reranker fallback behavior."""
+
+from unittest.mock import patch
+
+
+def test_reranker_load_failure_returns_rrf_order(monkeypatch):
+    """A missing offline reranker model must not fail search results."""
+    from mcp_server.server import CrossEncoderReranker
+
+    monkeypatch.setattr("mcp_server.server.config.reranker_enabled", True)
+
+    docs = [
+        {"document": "first", "rrf_score": 0.2},
+        {"document": "second", "rrf_score": 0.1},
+    ]
+    reranker = CrossEncoderReranker()
+
+    with patch("mcp_server.server.TextCrossEncoder", side_effect=RuntimeError("offline")):
+        assert reranker.rerank("query", docs, top_k=1) == [docs[0]]
+        assert reranker._load_failed is True
+
+
+def test_reranker_does_not_retry_after_load_failure(monkeypatch):
+    """Avoid repeated network attempts after a known load failure."""
+    from mcp_server.server import CrossEncoderReranker
+
+    monkeypatch.setattr("mcp_server.server.config.reranker_enabled", True)
+
+    reranker = CrossEncoderReranker()
+    reranker._load_failed = True
+
+    with patch("mcp_server.server.TextCrossEncoder") as text_cross_encoder:
+        result = reranker.rerank("query", [{"document": "first"}], top_k=1)
+
+    assert result == [{"document": "first"}]
+    text_cross_encoder.assert_not_called()


### PR DESCRIPTION
This PR fixes two failure modes observed in real MCP usage:

- ChromaDB can crash the Python process with a native segfault while opening a corrupted persistent index. Python `try/except` cannot recover from that.
- The reranker can fail on offline machines if its model is not already cached, causing `search_knowledge` to fail instead of returning available hybrid search results.

The fix adds a startup preflight that checks ChromaDB in a child process and moves a broken index aside before MCP initialization. It also keeps the reranker enabled by default, but falls back to hybrid RRF ordering if the reranker model cannot be loaded.

This keeps normal behavior unchanged when everything is healthy, while making the MCP server recoverable and usable offline.

## Summary

This PR makes the MCP server more robust in two startup/search failure cases:

1. ChromaDB persistent storage can crash the Python process with a native segfault during startup, before normal Python exception handling can recover.
2. The cross-encoder reranker is lazy-loaded on first query. If the reranker model is not cached and the machine is offline, `search_knowledge` currently fails instead of returning hybrid search results.

It also fixes virtualenv project-root detection when the venv Python executable is a symlink that resolves to the system Python.

## Problem

In a local Codex/Claude MCP setup, `search_knowledge` repeatedly became unavailable.

Observed failures:

- `chromadb` could segfault on `collection.count()` while opening an existing persistent index.
- Because this is a native crash, `try/except` around Chroma calls cannot catch it.
- If `KNOWLEDGE_RAG_DIR` / project root resolution is wrong, FastEmbed can look in the wrong model cache and try to download models at startup.
- If the reranker model is not cached, first query can fail on offline machines with a Hugging Face download error.

## Solution

This PR adds:

- `mcp_server/preflight.py`
  - probes ChromaDB in a child process before MCP initialization;
  - if the probe crashes or fails, moves the active `chroma_db/` and `index_metadata.json` into `data/backups/auto-repair-*`;
  - lets the next startup rebuild cleanly instead of killing the MCP server process.

- Startup integration in `server.main()`
  - runs preflight before constructing `KnowledgeOrchestrator`.

- Reranker graceful fallback
  - if `TextCrossEncoder` cannot load, search falls back to existing RRF order from hybrid semantic + BM25 retrieval;
  - avoids repeated load attempts after a known failure during the same server process.

- Virtualenv root detection fix
  - checks `sys.prefix`, unresolved `sys.executable`, and resolved `sys.executable`;
  - handles venv Python symlinks that resolve to `/usr/bin/python`.

- `knowledge-rag-guarded`
  - explicit guarded startup alias, while the default `knowledge-rag` entry point also runs preflight.

## Behavior change

Reranker remains enabled by default.

If the reranker model is available, behavior is unchanged.

If the reranker model is unavailable and the machine is offline, search no longer fails. It returns hybrid RRF-ranked results instead. This may reduce ranking precision for ambiguous queries, but keeps the MCP tool usable.

## Tests

Added tests for:

- Chroma preflight backup on probe failure.
- Chroma preflight no-op on healthy probe.
- Reranker load failure fallback.
- Avoiding repeated reranker load attempts after failure.
- Virtualenv project-root detection with symlinked Python.

Test result:

```text
99 passed
