### PR TITLE
Add single-instance guard for MCP stdio server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,6 +1016,17 @@ knowledge-rag
 knowledge-rag-guarded
 ```
 
+### Multiple MCP clients start duplicate servers
+
+MCP stdio clients can open more than one `knowledge-rag` process when multiple
+sessions or approval/review flows connect at the same time. Each process loads
+its own embedding model, ChromaDB client, BM25 state, and file watcher, which can
+consume significant memory.
+
+Startup now creates `data/knowledge-rag.lock` and refuses to start a second
+server while another instance is running. If the previous process crashed, stale
+locks are detected by PID and removed automatically.
+
 ### Index is empty
 
 ```bash

--- a/mcp_server/instance_lock.py
+++ b/mcp_server/instance_lock.py
@@ -1,0 +1,87 @@
+"""Single-instance guard for the MCP server process."""
+
+from __future__ import annotations
+
+import os
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from .config import config
+
+LOCK_FILENAME = "knowledge-rag.lock"
+ALREADY_RUNNING_EXIT_CODE = 75
+
+
+class AlreadyRunningError(RuntimeError):
+    """Raised when another knowledge-rag server instance already holds the lock."""
+
+
+def _pid_is_running(pid: int) -> bool:
+    """Return True if a process with PID appears to be alive."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _read_lock_pid(lock_path: Path) -> int | None:
+    try:
+        raw = lock_path.read_text(encoding="utf-8").strip().splitlines()[0]
+        return int(raw)
+    except (IndexError, OSError, ValueError):
+        return None
+
+
+def _lock_path() -> Path:
+    return config.data_dir / LOCK_FILENAME
+
+
+@contextmanager
+def single_instance_lock() -> Iterator[Path]:
+    """Hold an exclusive process-level lock for one MCP server instance."""
+    config.data_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = _lock_path()
+
+    while True:
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError:
+            pid = _read_lock_pid(lock_path)
+            if pid is not None and _pid_is_running(pid):
+                raise AlreadyRunningError(
+                    f"knowledge-rag MCP server is already running (pid {pid}). Refusing to start a second instance."
+                )
+
+            try:
+                lock_path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                print(
+                    f"[ERROR] Failed to clear stale lock {lock_path}: {exc}",
+                    file=sys.stderr,
+                )
+                raise AlreadyRunningError(f"Failed to clear stale lock {lock_path}: {exc}") from exc
+            continue
+
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(f"{os.getpid()}\n")
+        break
+
+    try:
+        yield lock_path
+    finally:
+        if _read_lock_pid(lock_path) == os.getpid():
+            try:
+                lock_path.unlink()
+            except FileNotFoundError:
+                pass

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1934,48 +1934,54 @@ def main():
         _handle_init()
         return
 
+    from .instance_lock import ALREADY_RUNNING_EXIT_CODE, AlreadyRunningError, single_instance_lock
     from .preflight import run_preflight
 
-    run_preflight()
-
-    orchestrator = get_orchestrator()
-
-    # Migration: check dimension mismatch AFTER full init (avoids segfault during __init__)
-    orchestrator._needs_rebuild = orchestrator._check_dimension_mismatch()
-    if orchestrator._needs_rebuild:
-        print("[MIGRATION] Running nuclear rebuild for embedding model change...")
-        try:
-            stats = orchestrator.nuclear_rebuild()
-            print(
-                f"[MIGRATION] Rebuild complete: {stats['indexed']} docs, "
-                f"{stats['chunks_added']} chunks in {stats.get('elapsed_seconds', '?')}s"
-            )
-        except Exception as e:
-            print(f"[ERROR] Migration failed: {e}")
-            print("[FALLBACK] Attempting regular index instead...")
-            stats = orchestrator.index_all(force=True)
-    elif orchestrator.collection.count() == 0:
-        print("[INFO] No documents indexed. Running initial indexing...")
-        stats = orchestrator.index_all()
-        print(f"[INFO] Indexed {stats['indexed']} documents with {stats['chunks_added']} chunks")
-
-    # Start file watcher for auto-reindex on document changes
     try:
-        watcher = DocumentWatcher(get_orchestrator, debounce_seconds=5.0)
-        observer = Observer()
-        observer.schedule(watcher, str(config.documents_dir), recursive=True)
-        observer.daemon = True
-        observer.start()
-        print(f"[WATCHER] Monitoring {config.documents_dir} for changes")
-    except Exception as e:
-        print(f"[WARN] Failed to start file watcher: {e}")
-        print("[WARN] Auto-reindexing disabled. Use reindex_documents tool manually.")
+        with single_instance_lock():
+            run_preflight()
 
-    # Restore real stdout for MCP JSON-RPC, keep print() going to stderr
-    from . import _original_stdout
+            orchestrator = get_orchestrator()
 
-    sys.stdout = _original_stdout
-    mcp.run()
+            # Migration: check dimension mismatch AFTER full init (avoids segfault during __init__)
+            orchestrator._needs_rebuild = orchestrator._check_dimension_mismatch()
+            if orchestrator._needs_rebuild:
+                print("[MIGRATION] Running nuclear rebuild for embedding model change...")
+                try:
+                    stats = orchestrator.nuclear_rebuild()
+                    print(
+                        f"[MIGRATION] Rebuild complete: {stats['indexed']} docs, "
+                        f"{stats['chunks_added']} chunks in {stats.get('elapsed_seconds', '?')}s"
+                    )
+                except Exception as e:
+                    print(f"[ERROR] Migration failed: {e}")
+                    print("[FALLBACK] Attempting regular index instead...")
+                    stats = orchestrator.index_all(force=True)
+            elif orchestrator.collection.count() == 0:
+                print("[INFO] No documents indexed. Running initial indexing...")
+                stats = orchestrator.index_all()
+                print(f"[INFO] Indexed {stats['indexed']} documents with {stats['chunks_added']} chunks")
+
+            # Start file watcher for auto-reindex on document changes
+            try:
+                watcher = DocumentWatcher(get_orchestrator, debounce_seconds=5.0)
+                observer = Observer()
+                observer.schedule(watcher, str(config.documents_dir), recursive=True)
+                observer.daemon = True
+                observer.start()
+                print(f"[WATCHER] Monitoring {config.documents_dir} for changes")
+            except Exception as e:
+                print(f"[WARN] Failed to start file watcher: {e}")
+                print("[WARN] Auto-reindexing disabled. Use reindex_documents tool manually.")
+
+            # Restore real stdout for MCP JSON-RPC, keep print() going to stderr
+            from . import _original_stdout
+
+            sys.stdout = _original_stdout
+            mcp.run()
+    except AlreadyRunningError as e:
+        print(f"[ERROR] {e}", file=sys.stderr)
+        raise SystemExit(ALREADY_RUNNING_EXIT_CODE) from e
 
 
 if __name__ == "__main__":

--- a/tests/test_guarded.py
+++ b/tests/test_guarded.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import pytest
+
+
+def test_single_instance_lock_rejects_second_process(monkeypatch, tmp_path):
+    from mcp_server import instance_lock
+
+    monkeypatch.setattr(instance_lock.config, "data_dir", tmp_path)
+
+    with instance_lock.single_instance_lock():
+        with pytest.raises(instance_lock.AlreadyRunningError):
+            with instance_lock.single_instance_lock():
+                pass
+
+
+def test_single_instance_lock_recovers_stale_pid(monkeypatch, tmp_path):
+    from mcp_server import instance_lock
+
+    lock_path = Path(tmp_path) / "knowledge-rag.lock"
+    lock_path.write_text("999999999\n", encoding="utf-8")
+
+    monkeypatch.setattr(instance_lock.config, "data_dir", tmp_path)
+    monkeypatch.setattr(instance_lock, "_pid_is_running", lambda pid: False)
+
+    with instance_lock.single_instance_lock():
+        assert lock_path.read_text(encoding="utf-8").strip() == str(instance_lock.os.getpid())
+
+    assert not lock_path.exists()


### PR DESCRIPTION
Hi @lyonzin,

This PR adds a single-instance guard for the `knowledge-rag` MCP server.

## Problem

Some MCP stdio clients can start multiple `knowledge-rag` processes even during a single visible user session/request. In my case this happened from one chat: the client opened additional internal MCP connections during approval/review flow, so several independent `knowledge-rag` processes were spawned although I was not intentionally running parallel chats.

Each process loads its own embedding model, ChromaDB client, BM25 state, and file watcher. On larger local indexes this can quickly consume several GB of RAM and may exhaust system memory.

## Fix

The server now creates `data/knowledge-rag.lock` on startup and refuses to start a second instance while the first one is still alive.

The guard:

- writes the current PID to the lock file;
- checks whether an existing PID is still running;
- exits with code `75` if another server is active;
- removes stale lock files when the previous process is gone;
- cleans up the lock on normal termination and SIGINT/SIGTERM.

The lock is applied in `server.main()`, so it protects all entry points that run the MCP server, including direct `knowledge-rag`, `python -m mcp_server.server`, and wrapper-based launches.

## Validation

I reproduced the issue by starting multiple MCP stdio server instances with open stdin. Each instance stayed alive independently and loaded its own model/watcher.

After this patch, the second server exits immediately with:

`knowledge-rag MCP server is already running`

Added tests cover:

- rejecting a second running instance;
- recovering from a stale lock file.
