### PR TITLE
feat(embeddings): lazy-load FastEmbed model on first call

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -136,6 +136,17 @@ class FastEmbedEmbeddings:
     Uses ONNX Runtime in-process for embedding generation.
     No external server required (replaces Ollama).
     Model: BAAI/bge-small-en-v1.5 (384-dim, MTEB score 62.x)
+
+    Lazy-loading (since v3.8.0):
+        The ONNX model (~200MB resident) is NOT loaded in __init__.
+        It loads on the first call to __call__/embed_query/embed_documents.
+        This makes idle MCP server processes cheap, which matters when
+        multiple stdio clients spawn parallel knowledge-rag processes
+        (e.g. multiple Claude Code windows). The CrossEncoderReranker
+        already follows this same pattern.
+
+        Thread-safe: load is guarded by a lock so concurrent first-callers
+        don't double-initialize the model.
     """
 
     @staticmethod
@@ -174,20 +185,34 @@ class FastEmbedEmbeddings:
     def __init__(self, model: str = None):
         self.model_name = model or config.embedding_model
         self._dim = config.embedding_dim
-        kwargs = {"model_name": self.model_name, "cache_dir": str(config.models_cache_dir)}
-        if config.gpu_acceleration:
-            self._setup_cuda_dll_paths()
-            kwargs["providers"] = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-            print(f"[INFO] Loading embedding model: {self.model_name} ({self._dim}D) [GPU accelerated]...")
-            try:
-                self._model = TextEmbedding(**kwargs)
-                print("[INFO] Embedding model loaded successfully [GPU]")
-            except (ValueError, RuntimeError) as e:
-                print(f"[WARN] GPU init failed ({e}), falling back to CPU...")
-                kwargs["providers"] = ["CPUExecutionProvider"]
-                self._model = TextEmbedding(**kwargs)
-                print("[INFO] Embedding model loaded successfully [CPU fallback]")
-        else:
+        # Build kwargs once; defer the heavy TextEmbedding(**kwargs) call to first use.
+        self._init_kwargs = {"model_name": self.model_name, "cache_dir": str(config.models_cache_dir)}
+        self._gpu = bool(config.gpu_acceleration)
+        self._model: Optional[TextEmbedding] = None
+        self._load_lock = threading.Lock()
+
+    def _load_model(self) -> None:
+        """Load the ONNX model on demand. Idempotent and thread-safe."""
+        if self._model is not None:
+            return
+        with self._load_lock:
+            if self._model is not None:  # double-checked under the lock
+                return
+            kwargs = dict(self._init_kwargs)
+            if self._gpu:
+                self._setup_cuda_dll_paths()
+                kwargs["providers"] = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+                print(f"[INFO] Loading embedding model: {self.model_name} ({self._dim}D) [GPU accelerated]...")
+                try:
+                    self._model = TextEmbedding(**kwargs)
+                    print("[INFO] Embedding model loaded successfully [GPU]")
+                    return
+                except (ValueError, RuntimeError) as e:
+                    print(f"[WARN] GPU init failed ({e}), falling back to CPU...")
+                    kwargs["providers"] = ["CPUExecutionProvider"]
+                    self._model = TextEmbedding(**kwargs)
+                    print("[INFO] Embedding model loaded successfully [CPU fallback]")
+                    return
             kwargs["providers"] = ["CPUExecutionProvider"]
             print(f"[INFO] Loading embedding model: {self.model_name} ({self._dim}D)...")
             self._model = TextEmbedding(**kwargs)
@@ -203,6 +228,7 @@ class FastEmbedEmbeddings:
         if not input:
             return []
 
+        self._load_model()
         try:
             embeddings = list(self._model.embed(input))
             return [emb.tolist() for emb in embeddings]

--- a/tests/test_lazy_embeddings.py
+++ b/tests/test_lazy_embeddings.py
@@ -1,0 +1,118 @@
+"""Tests for lazy initialization of FastEmbedEmbeddings (v3.8.0+).
+
+The embedding model is heavy (~200MB resident). We defer the load to the
+first real call so idle MCP server processes stay cheap. This matters when
+multiple stdio clients spawn parallel knowledge-rag processes.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, patch
+
+
+def _make_embedder():
+    """Build a FastEmbedEmbeddings instance without triggering ONNX load."""
+    from mcp_server.server import FastEmbedEmbeddings
+
+    return FastEmbedEmbeddings()
+
+
+def test_init_does_not_load_model():
+    """Constructing the embedder must not touch TextEmbedding (no model load)."""
+    with patch("mcp_server.server.TextEmbedding") as mock_te:
+        emb = _make_embedder()
+        assert emb._model is None
+        mock_te.assert_not_called()
+
+
+def test_first_call_loads_model():
+    """The first __call__ must materialize the model exactly once."""
+    fake_model = MagicMock()
+    fake_model.embed.return_value = iter([])
+    with patch("mcp_server.server.TextEmbedding", return_value=fake_model) as mock_te:
+        emb = _make_embedder()
+        assert emb._model is None
+        emb([])  # empty input short-circuits before embedding, but _load is fine to skip
+        # Empty input returns early — confirm by triggering with real text
+        emb(["hello"])
+        assert emb._model is fake_model
+        assert mock_te.call_count == 1
+
+
+def test_second_call_reuses_model():
+    """Subsequent calls must NOT reload the model (idempotent _load_model)."""
+    fake_model = MagicMock()
+    fake_model.embed.side_effect = lambda texts: iter([])
+    with patch("mcp_server.server.TextEmbedding", return_value=fake_model) as mock_te:
+        emb = _make_embedder()
+        emb(["one"])
+        emb(["two"])
+        emb(["three"])
+        assert mock_te.call_count == 1
+
+
+def test_embed_query_triggers_load():
+    """embed_query path must also trigger lazy load."""
+    fake_model = MagicMock()
+    fake_model.embed.return_value = iter([])
+    with patch("mcp_server.server.TextEmbedding", return_value=fake_model) as mock_te:
+        emb = _make_embedder()
+        assert emb._model is None
+        emb.embed_query("query text")
+        assert mock_te.call_count == 1
+
+
+def test_embed_documents_triggers_load():
+    """embed_documents path must also trigger lazy load."""
+    fake_model = MagicMock()
+    fake_model.embed.return_value = iter([])
+    with patch("mcp_server.server.TextEmbedding", return_value=fake_model) as mock_te:
+        emb = _make_embedder()
+        assert emb._model is None
+        emb.embed_documents(["doc"])
+        assert mock_te.call_count == 1
+
+
+def test_concurrent_first_call_loads_once():
+    """Two threads racing on the first call must trigger exactly ONE load.
+
+    The lock-protected _load_model is single-entry, so even a slow model
+    construction won't cause a duplicate init. We hold the first init briefly
+    to ensure the second thread arrives during the load and observes the lock.
+    """
+    fake_model = MagicMock()
+    fake_model.embed.return_value = iter([])
+    init_started = threading.Event()
+    release_init = threading.Event()
+
+    def slow_init(**kwargs):
+        init_started.set()
+        # Block here so the second thread has time to race on the lock
+        release_init.wait(timeout=2)
+        return fake_model
+
+    with patch("mcp_server.server.TextEmbedding", side_effect=slow_init) as mock_te:
+        emb = _make_embedder()
+        results = []
+
+        def worker():
+            emb(["text"])
+            results.append(True)
+
+        t1 = threading.Thread(target=worker)
+        t2 = threading.Thread(target=worker)
+        t1.start()
+        # Wait for thread 1 to be inside slow_init (holding the lock)
+        assert init_started.wait(timeout=2), "first thread never entered slow_init"
+        t2.start()
+        # Give t2 a moment to hit the lock
+        threading.Event().wait(0.05)
+        # Release t1's init; t2 should then exit fast via the double-checked guard
+        release_init.set()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        # Even with two threads racing, the model is constructed exactly once
+        assert mock_te.call_count == 1
+        assert len(results) == 2


### PR DESCRIPTION
## Summary

Defer the FastEmbed ONNX model load (~200MB resident) from `__init__` to the first `__call__`/`embed_query`/`embed_documents` invocation. Idle `knowledge-rag` processes drop their embedding-model cost until they actually need to embed.

## Why

MCP stdio clients spawn one `knowledge-rag` process per connection (per protocol). Multiple Claude Code windows, Claude Desktop + IDE simultaneously, or review/approval flows that open extra connections result in N processes, each holding a full ONNX model copy resident. On larger setups this can be several GB.

The reranker already follows this lazy pattern (`server.py:485-486`); the embedder was the remaining hot spot.

## Changes

- `mcp_server/server.py`
  - `FastEmbedEmbeddings.__init__` stores config + flags only — no `TextEmbedding(**kwargs)` call
  - New `_load_model()` helper: idempotent, thread-safe (double-checked `threading.Lock`)
  - `__call__` triggers `_load_model()` before embedding (skipped on empty input via existing short-circuit)
  - GPU/CPU fallback path preserved bit-for-bit
- `tests/test_lazy_embeddings.py` (new)
  - init does not load model
  - first call loads model
  - second call reuses model (no double load)
  - `embed_query` / `embed_documents` paths trigger load
  - concurrent first-callers race -> exactly one load

## Compatibility

- Public API unchanged
- GPU init + CPU fallback identical
- Same `[INFO]` log messages, emitted on first use instead of startup
- Empty-input early-return unchanged

## Test plan

- [ ] CI matrix green (Linux + Windows × 3.11 + 3.12)
- [ ] Local manual: `knowledge-rag` boots, no `[INFO] Loading embedding model` line until first `search_knowledge` call
- [ ] No regression in MRR@5 / Recall@5 (lazy only changes WHEN, not HOW)

Closes part of the work toward addressing memory bloat reported in #31.