### PR TITLE
feat(server): opt-in single-instance guard (KNOWLEDGE_RAG_SINGLE_INSTANCE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1050,7 +1050,17 @@ The cross-encoder reranker model is lazy-loaded on the first query. This adds a 
 
 ### Memory usage
 
-With ~200 documents, expect ~300-500MB RAM. The embedding model (~50MB) and reranker (~25MB) are loaded into memory. For very large knowledge bases (1000+ documents), consider enabling GPU acceleration and using exclude patterns to limit index scope.
+With ~200 documents, expect ~300-500MB RAM. The embedding model (~200MB ONNX runtime resident, lazy-loaded on first query since v3.8.0) and reranker (~25MB, lazy-loaded) are loaded into memory only when actually used. For very large knowledge bases (1000+ documents), consider enabling GPU acceleration and using exclude patterns to limit index scope.
+
+### Multiple MCP clients spawn duplicate servers
+
+MCP stdio is one process per client by protocol — multiple Claude Code windows, Claude Desktop + IDE, etc. each spawn their own `knowledge-rag` process. Since v3.8.0 idle processes are cheap (no embedding model loaded until first query). If you've measured and want a hard cap of one server per data directory, opt in:
+
+```bash
+export KNOWLEDGE_RAG_SINGLE_INSTANCE=1
+```
+
+A second instance exits immediately with code 75. Default is OFF (multi-client friendly). Full guide: [docs/single-instance.md](docs/single-instance.md). Sample MCP config: [examples/mcp-config-single-instance.json](examples/mcp-config-single-instance.json).
 
 ---
 

--- a/docs/single-instance.md
+++ b/docs/single-instance.md
@@ -1,0 +1,104 @@
+# Single-Instance Mode (opt-in)
+
+> **TL;DR**: knowledge-rag now supports an opt-in flag that prevents more than one server process from running against the same data directory at the same time. **It is OFF by default** — multi-client MCP usage continues to work exactly as before. Turn it on only if you know you want it.
+
+---
+
+## When you might want this
+
+MCP stdio servers are 1-process-per-client by protocol design. Some scenarios spawn more processes than you expected:
+
+- Some MCP clients open extra internal connections during approval / review / multi-agent flows
+- Long-running CI jobs accidentally launching parallel server processes
+- A misbehaving wrapper script that re-launches knowledge-rag in a loop
+
+Each `knowledge-rag` process holds its own:
+- Embedding model (since v3.8.0 this is **lazy-loaded** — idle processes are cheap; only processes that actually serve queries pay the ~200MB cost)
+- ChromaDB client + SQLite handles
+- BM25 in-memory index
+- Watchdog file observer
+
+If you've measured and confirmed you really do want a hard cap of one server per data directory, this flag is for you.
+
+## When you should NOT enable it
+
+- You run multiple Claude Code windows simultaneously and want all of them to use this RAG
+- You have Claude Desktop + an IDE + a terminal session all wired to the same RAG
+- You run knowledge-rag inside an automation that expects to be able to spin up parallel readers
+- You don't have a measured memory problem
+
+For all of the above, **leave the flag unset**. The lazy-load improvement in v3.8.0 already cuts most of the per-process cost.
+
+## Activation
+
+Set the environment variable in your MCP client config. Accepted truthy values (case-insensitive, surrounding whitespace ignored): `1`, `true`, `yes`, `on`. Anything else, including unset, leaves the guard disabled.
+
+### Claude Code / Claude Desktop (`mcp.json` / `claude_desktop_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "knowledge-rag": {
+      "command": "knowledge-rag",
+      "env": {
+        "KNOWLEDGE_RAG_SINGLE_INSTANCE": "1"
+      }
+    }
+  }
+}
+```
+
+### Shell
+
+```bash
+export KNOWLEDGE_RAG_SINGLE_INSTANCE=1
+knowledge-rag
+```
+
+### PowerShell
+
+```powershell
+$env:KNOWLEDGE_RAG_SINGLE_INSTANCE = "1"
+knowledge-rag
+```
+
+## What you'll see
+
+A second process starting against the same data directory exits immediately with code `75` (`EX_TEMPFAIL` from `sysexits.h`) and writes to stderr:
+
+```
+[ERROR] knowledge-rag MCP server is already running (pid 12345). Refusing to start a second instance because KNOWLEDGE_RAG_SINGLE_INSTANCE is enabled.
+```
+
+## How it works
+
+- On startup, the server creates `<data_dir>/knowledge-rag.lock` with `O_CREAT | O_EXCL` and writes its PID inside.
+- A second startup attempt finds the existing file, reads the PID, and probes whether that PID is still alive.
+  - **Alive** -> exits with `AlreadyRunningError`.
+  - **Dead** (crashed, killed) -> the lock is recognized as stale, removed, and the new process acquires it.
+- Cleanup runs in three places so the lock never outlives the process:
+  1. Normal exit -> `finally` block in the contextmanager removes the lock.
+  2. `SIGINT` / `SIGTERM` -> handlers remove the lock and re-raise the signal so the original disposition fires.
+  3. `SIGKILL` / hard crash -> stale-PID detection on the next startup recovers it.
+
+The lock is per-data-directory. Two RAGs configured with different `data_dir` values do not collide.
+
+## Troubleshooting
+
+**"It says already running but I just killed the process"**
+The lock should self-recover via stale-PID detection on the next startup. If it doesn't (e.g. PID was reused by an unrelated process), delete `<data_dir>/knowledge-rag.lock` manually.
+
+**"I want this off again"**
+Remove the env var from your MCP client config (or set it to `0` / `false`). On the next launch the guard is a complete no-op — no lock file is created and no checks happen.
+
+**"Stale lock left after Windows shutdown"**
+Expected. Stale-PID detection clears it on the next startup. You can also delete the file manually.
+
+## Roadmap
+
+The single-instance guard is a stop-gap. The proper fix for shared resources across multiple MCP clients is a **shared service architecture** (one daemon holding the model + index, many thin MCP clients connecting via socket). That work is tracked for v4.0.
+
+## Credits
+
+- Original guard concept and reproduction: [Sergey Khokhlov (@Hohlas)](https://github.com/Hohlas) in [PR #31](https://github.com/lyonzin/knowledge-rag/pull/31).
+- Reworked as opt-in (default off), signal handlers wired, expanded test coverage: knowledge-rag maintainers.

--- a/examples/mcp-config-single-instance.json
+++ b/examples/mcp-config-single-instance.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Example MCP client config with the opt-in single-instance guard enabled. See docs/single-instance.md for full context. Default behavior (without this env var) allows multiple parallel knowledge-rag processes.",
+  "mcpServers": {
+    "knowledge-rag": {
+      "command": "knowledge-rag",
+      "env": {
+        "KNOWLEDGE_RAG_SINGLE_INSTANCE": "1"
+      }
+    }
+  }
+}

--- a/mcp_server/instance_lock.py
+++ b/mcp_server/instance_lock.py
@@ -41,7 +41,6 @@ from __future__ import annotations
 
 import os
 import signal
-import sys
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator, Optional
@@ -146,9 +145,7 @@ def single_instance_lock() -> Iterator[Optional[Path]]:
             except FileNotFoundError:
                 pass
             except OSError as exc:
-                raise AlreadyRunningError(
-                    f"Failed to clear stale lock {lock_path}: {exc}"
-                ) from exc
+                raise AlreadyRunningError(f"Failed to clear stale lock {lock_path}: {exc}") from exc
             continue
 
         with os.fdopen(fd, "w", encoding="utf-8") as f:

--- a/mcp_server/instance_lock.py
+++ b/mcp_server/instance_lock.py
@@ -1,0 +1,191 @@
+"""Optional single-instance guard for the MCP server process.
+
+Background
+----------
+MCP stdio servers are 1-process-per-client by protocol design. Multiple
+Claude Code windows, Claude Desktop + IDE running simultaneously, or clients
+that open extra internal connections during approval/review flows will all
+spawn additional `knowledge-rag` processes. Each process holds its own
+embedding model, ChromaDB client, BM25 state, and file watcher.
+
+Lazy-loading the embedding model (v3.8.0) reduces idle cost dramatically,
+but some users still want a hard cap of one process per data directory.
+This module provides that cap as an OPT-IN, never as a default.
+
+Activation
+----------
+Set the environment variable in your MCP client config:
+
+    KNOWLEDGE_RAG_SINGLE_INSTANCE=1     # also accepts: true, yes, on (case-insensitive)
+
+When unset (default), `single_instance_lock()` is a no-op and the server
+behaves exactly as it did before this module existed.
+
+When enabled, the server creates `<data_dir>/knowledge-rag.lock` containing
+its PID. A second process starting against the same `data_dir` will detect
+the live PID and exit with code 75 (EX_TEMPFAIL). Stale locks (PID gone)
+are cleaned up automatically.
+
+Cleanup is wired in three places so the lock does not outlive the process:
+1. Normal exit: contextmanager `finally` block removes the lock.
+2. SIGINT / SIGTERM: handlers remove the lock and re-raise the default action.
+3. Crash / SIGKILL: stale-PID detection on the next startup removes it.
+
+Authors
+-------
+- Concept and original guard: Sergey Khokhlov (@Hohlas) in PR #31
+- Reworked as opt-in + signal handlers + tests: Lyon. (knowledge-rag maintainer)
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+
+from .config import config
+
+LOCK_FILENAME = "knowledge-rag.lock"
+ALREADY_RUNNING_EXIT_CODE = 75  # EX_TEMPFAIL from sysexits.h
+ENV_VAR = "KNOWLEDGE_RAG_SINGLE_INSTANCE"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+class AlreadyRunningError(RuntimeError):
+    """Raised when another knowledge-rag server instance already holds the lock."""
+
+
+def single_instance_enabled() -> bool:
+    """Return True if the user opted into the single-instance guard.
+
+    Reads `KNOWLEDGE_RAG_SINGLE_INSTANCE`. Accepts ``1``, ``true``, ``yes``, ``on``
+    (case-insensitive, surrounding whitespace ignored). Anything else — including
+    unset, empty, ``0``, ``false`` — leaves the guard disabled.
+    """
+    raw = os.environ.get(ENV_VAR, "").strip().lower()
+    return raw in _TRUTHY
+
+
+def _pid_is_running(pid: int) -> bool:
+    """Return True if a process with PID appears to be alive."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but is owned by another user / has tighter ACLs
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _read_lock_pid(lock_path: Path) -> Optional[int]:
+    try:
+        raw = lock_path.read_text(encoding="utf-8").strip().splitlines()[0]
+        return int(raw)
+    except (IndexError, OSError, ValueError):
+        return None
+
+
+def _lock_path() -> Path:
+    return config.data_dir / LOCK_FILENAME
+
+
+def _remove_if_ours(lock_path: Path) -> None:
+    """Remove the lock file ONLY if it still references our PID."""
+    if _read_lock_pid(lock_path) == os.getpid():
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            # Best-effort; stale-PID check on next startup will recover
+            pass
+
+
+@contextmanager
+def single_instance_lock() -> Iterator[Optional[Path]]:
+    """Acquire the single-instance lock if opt-in flag is set.
+
+    No-op when ``KNOWLEDGE_RAG_SINGLE_INSTANCE`` is unset / falsy — yields ``None``
+    and the caller proceeds normally with no side effects on disk.
+
+    When enabled:
+      - Creates ``<data_dir>/knowledge-rag.lock`` containing this process's PID.
+      - Raises :class:`AlreadyRunningError` if another live PID already holds it.
+      - Recovers stale locks (PID no longer running).
+      - Registers SIGINT/SIGTERM handlers that remove the lock and re-raise.
+      - Removes the lock on normal exit via ``finally``.
+    """
+    if not single_instance_enabled():
+        yield None
+        return
+
+    config.data_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = _lock_path()
+
+    while True:
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError:
+            pid = _read_lock_pid(lock_path)
+            if pid is not None and _pid_is_running(pid):
+                raise AlreadyRunningError(
+                    f"knowledge-rag MCP server is already running (pid {pid}). "
+                    f"Refusing to start a second instance because "
+                    f"{ENV_VAR} is enabled."
+                )
+            try:
+                lock_path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                raise AlreadyRunningError(
+                    f"Failed to clear stale lock {lock_path}: {exc}"
+                ) from exc
+            continue
+
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(f"{os.getpid()}\n")
+        break
+
+    # Wire signal handlers so SIGINT/SIGTERM cleanup the lock before exit
+    previous_handlers: dict[int, object] = {}
+
+    def _signal_cleanup(signum: int, frame) -> None:
+        _remove_if_ours(lock_path)
+        # Restore original handler and re-raise so default action runs
+        prev = previous_handlers.get(signum, signal.SIG_DFL)
+        try:
+            signal.signal(signum, prev)  # type: ignore[arg-type]
+        except (ValueError, OSError):
+            pass
+        # Re-send the signal to ourselves so the original disposition fires
+        os.kill(os.getpid(), signum)
+
+    for sig_name in ("SIGINT", "SIGTERM"):
+        sig = getattr(signal, sig_name, None)
+        if sig is None:
+            continue
+        try:
+            previous_handlers[sig] = signal.getsignal(sig)
+            signal.signal(sig, _signal_cleanup)
+        except (ValueError, OSError):
+            # signal.signal raises if not on the main thread; tests may hit this
+            pass
+
+    try:
+        yield lock_path
+    finally:
+        _remove_if_ours(lock_path)
+        for sig, prev in previous_handlers.items():
+            try:
+                signal.signal(sig, prev)  # type: ignore[arg-type]
+            except (ValueError, OSError):
+                pass

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1934,48 +1934,58 @@ def main():
         _handle_init()
         return
 
+    from .instance_lock import (
+        ALREADY_RUNNING_EXIT_CODE,
+        AlreadyRunningError,
+        single_instance_lock,
+    )
     from .preflight import run_preflight
 
-    run_preflight()
-
-    orchestrator = get_orchestrator()
-
-    # Migration: check dimension mismatch AFTER full init (avoids segfault during __init__)
-    orchestrator._needs_rebuild = orchestrator._check_dimension_mismatch()
-    if orchestrator._needs_rebuild:
-        print("[MIGRATION] Running nuclear rebuild for embedding model change...")
-        try:
-            stats = orchestrator.nuclear_rebuild()
-            print(
-                f"[MIGRATION] Rebuild complete: {stats['indexed']} docs, "
-                f"{stats['chunks_added']} chunks in {stats.get('elapsed_seconds', '?')}s"
-            )
-        except Exception as e:
-            print(f"[ERROR] Migration failed: {e}")
-            print("[FALLBACK] Attempting regular index instead...")
-            stats = orchestrator.index_all(force=True)
-    elif orchestrator.collection.count() == 0:
-        print("[INFO] No documents indexed. Running initial indexing...")
-        stats = orchestrator.index_all()
-        print(f"[INFO] Indexed {stats['indexed']} documents with {stats['chunks_added']} chunks")
-
-    # Start file watcher for auto-reindex on document changes
     try:
-        watcher = DocumentWatcher(get_orchestrator, debounce_seconds=5.0)
-        observer = Observer()
-        observer.schedule(watcher, str(config.documents_dir), recursive=True)
-        observer.daemon = True
-        observer.start()
-        print(f"[WATCHER] Monitoring {config.documents_dir} for changes")
-    except Exception as e:
-        print(f"[WARN] Failed to start file watcher: {e}")
-        print("[WARN] Auto-reindexing disabled. Use reindex_documents tool manually.")
+        with single_instance_lock():
+            run_preflight()
 
-    # Restore real stdout for MCP JSON-RPC, keep print() going to stderr
-    from . import _original_stdout
+            orchestrator = get_orchestrator()
 
-    sys.stdout = _original_stdout
-    mcp.run()
+            # Migration: check dimension mismatch AFTER full init (avoids segfault during __init__)
+            orchestrator._needs_rebuild = orchestrator._check_dimension_mismatch()
+            if orchestrator._needs_rebuild:
+                print("[MIGRATION] Running nuclear rebuild for embedding model change...")
+                try:
+                    stats = orchestrator.nuclear_rebuild()
+                    print(
+                        f"[MIGRATION] Rebuild complete: {stats['indexed']} docs, "
+                        f"{stats['chunks_added']} chunks in {stats.get('elapsed_seconds', '?')}s"
+                    )
+                except Exception as e:
+                    print(f"[ERROR] Migration failed: {e}")
+                    print("[FALLBACK] Attempting regular index instead...")
+                    stats = orchestrator.index_all(force=True)
+            elif orchestrator.collection.count() == 0:
+                print("[INFO] No documents indexed. Running initial indexing...")
+                stats = orchestrator.index_all()
+                print(f"[INFO] Indexed {stats['indexed']} documents with {stats['chunks_added']} chunks")
+
+            # Start file watcher for auto-reindex on document changes
+            try:
+                watcher = DocumentWatcher(get_orchestrator, debounce_seconds=5.0)
+                observer = Observer()
+                observer.schedule(watcher, str(config.documents_dir), recursive=True)
+                observer.daemon = True
+                observer.start()
+                print(f"[WATCHER] Monitoring {config.documents_dir} for changes")
+            except Exception as e:
+                print(f"[WARN] Failed to start file watcher: {e}")
+                print("[WARN] Auto-reindexing disabled. Use reindex_documents tool manually.")
+
+            # Restore real stdout for MCP JSON-RPC, keep print() going to stderr
+            from . import _original_stdout
+
+            sys.stdout = _original_stdout
+            mcp.run()
+    except AlreadyRunningError as e:
+        print(f"[ERROR] {e}", file=sys.stderr)
+        raise SystemExit(ALREADY_RUNNING_EXIT_CODE) from e
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,11 @@ exclude = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+# Limit retained tmp_path directories to avoid pytest's atexit cleanup race
+# on Windows (cleanup_numbered_dir + pathlib.glob "garbage-*" can fail when
+# many tmp dirs accumulate). Tests run isolated; we don't need history.
+tmp_path_retention_count = 1
+tmp_path_retention_policy = "failed"
 
 [tool.ruff]
 target-version = "py311"

--- a/tests/test_instance_lock.py
+++ b/tests/test_instance_lock.py
@@ -1,0 +1,156 @@
+"""Tests for the opt-in single-instance guard (v3.8.0+).
+
+Behavior contract:
+- Default OFF: contextmanager is a no-op, no lock file created.
+- Opt-in via KNOWLEDGE_RAG_SINGLE_INSTANCE=1 (also: true/yes/on, case-insensitive).
+- Enabled: a second acquisition with the same live PID raises AlreadyRunningError.
+- Stale locks (PID gone) are recovered automatically.
+- Cleanup runs on normal exit (finally) and on SIGINT/SIGTERM.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Env-var parsing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "value",
+    ["1", "true", "TRUE", "True", "yes", "YES", "on", "ON", "  1  ", "  true  "],
+)
+def test_env_var_truthy_enables_guard(monkeypatch, value):
+    from mcp_server import instance_lock
+
+    monkeypatch.setenv(instance_lock.ENV_VAR, value)
+    assert instance_lock.single_instance_enabled() is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "0", "false", "FALSE", "no", "off", "anything", "  ", "2"],
+)
+def test_env_var_falsy_keeps_guard_disabled(monkeypatch, value):
+    from mcp_server import instance_lock
+
+    monkeypatch.setenv(instance_lock.ENV_VAR, value)
+    assert instance_lock.single_instance_enabled() is False
+
+
+def test_env_var_unset_keeps_guard_disabled(monkeypatch):
+    from mcp_server import instance_lock
+
+    monkeypatch.delenv(instance_lock.ENV_VAR, raising=False)
+    assert instance_lock.single_instance_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# No-op default
+# ---------------------------------------------------------------------------
+
+def test_disabled_by_default_is_noop(monkeypatch, tmp_path):
+    """Without the env var, the contextmanager creates NO lock file."""
+    from mcp_server import instance_lock
+
+    monkeypatch.delenv(instance_lock.ENV_VAR, raising=False)
+    monkeypatch.setattr(instance_lock.config, "data_dir", tmp_path)
+
+    with instance_lock.single_instance_lock() as lock:
+        assert lock is None
+        assert not (tmp_path / instance_lock.LOCK_FILENAME).exists()
+
+    # And nothing left behind after exit either
+    assert not (tmp_path / instance_lock.LOCK_FILENAME).exists()
+
+
+def test_disabled_allows_unlimited_concurrent_acquires(monkeypatch, tmp_path):
+    """With guard off, nesting acquires must NOT raise (multi-client friendly)."""
+    from mcp_server import instance_lock
+
+    monkeypatch.delenv(instance_lock.ENV_VAR, raising=False)
+    monkeypatch.setattr(instance_lock.config, "data_dir", tmp_path)
+
+    with instance_lock.single_instance_lock():
+        with instance_lock.single_instance_lock():
+            with instance_lock.single_instance_lock():
+                pass  # no AlreadyRunningError, ever
+
+
+# ---------------------------------------------------------------------------
+# Enabled-mode behavior
+# ---------------------------------------------------------------------------
+
+def test_enabled_creates_lock_with_pid(monkeypatch, tmp_path):
+    from mcp_server import instance_lock
+
+    monkeypatch.setenv(instance_lock.ENV_VAR, "1")
+    monkeypatch.setattr(instance_lock.config, "data_dir", tmp_path)
+
+    lock_path = tmp_path / instance_lock.LOCK_FILENAME
+    with instance_lock.single_instance_lock() as held:
+        assert held == lock_path
+        assert lock_path.exists()
+        assert lock_path.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+    # Cleaned up on normal exit
+    assert not lock_path.exists()
+
+
+def test_enabled_rejects_second_instance(monkeypatch, tmp_path):
+    from mcp_server import instance_lock
+
+    monkeypatch.setenv(instance_lock.ENV_VAR, "1")
+    monkeypatch.setattr(instance_lock.config, "data_dir", tmp_path)
+
+    with instance_lock.single_instance_lock():
+        with pytest.raises(instance_lock.AlreadyRunningError):
+            with instance_lock.single_instance_lock():
+                pass
+
+
+def test_enabled_recovers_stale_pid(monkeypatch, tmp_path):
+    """A lock file referencing a dead PID must be cleared and re-acquired."""
+    from mcp_server import instance_lock
+
+    monkeypatch.setenv(instance_lock.ENV_VAR, "1")
+    monkeypatch.setattr(instance_lock.config, "data_dir", tmp_path)
+    monkeypatch.setattr(instance_lock, "_pid_is_running", lambda pid: False)
+
+    lock_path = Path(tmp_path) / instance_lock.LOCK_FILENAME
+    lock_path.write_text("999999999\n", encoding="utf-8")
+
+    with instance_lock.single_instance_lock():
+        assert lock_path.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+    assert not lock_path.exists()
+
+
+def test_isolated_data_dirs_are_independent(monkeypatch, tmp_path):
+    """Two RAGs pointing at different data_dirs must hold independent locks."""
+    from mcp_server import instance_lock
+
+    monkeypatch.setenv(instance_lock.ENV_VAR, "1")
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+
+    monkeypatch.setattr(instance_lock.config, "data_dir", dir_a)
+    with instance_lock.single_instance_lock():
+        # Switching the configured data_dir to a sibling RAG must allow a fresh lock
+        monkeypatch.setattr(instance_lock.config, "data_dir", dir_b)
+        with instance_lock.single_instance_lock():
+            assert (dir_a / instance_lock.LOCK_FILENAME).exists()
+            assert (dir_b / instance_lock.LOCK_FILENAME).exists()
+
+
+def test_pid_check_handles_invalid_pid():
+    from mcp_server import instance_lock
+
+    assert instance_lock._pid_is_running(0) is False
+    assert instance_lock._pid_is_running(-1) is False

--- a/tests/test_instance_lock.py
+++ b/tests/test_instance_lock.py
@@ -15,10 +15,10 @@ from pathlib import Path
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Env-var parsing
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize(
     "value",
@@ -53,6 +53,7 @@ def test_env_var_unset_keeps_guard_disabled(monkeypatch):
 # No-op default
 # ---------------------------------------------------------------------------
 
+
 def test_disabled_by_default_is_noop(monkeypatch, tmp_path):
     """Without the env var, the contextmanager creates NO lock file."""
     from mcp_server import instance_lock
@@ -84,6 +85,7 @@ def test_disabled_allows_unlimited_concurrent_acquires(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 # Enabled-mode behavior
 # ---------------------------------------------------------------------------
+
 
 def test_enabled_creates_lock_with_pid(monkeypatch, tmp_path):
     from mcp_server import instance_lock


### PR DESCRIPTION
## Summary

Adds an **opt-in** single-instance guard for the MCP server. Default OFF: behavior identical to previous releases. Users who want a hard cap of one server per data directory enable it via `KNOWLEDGE_RAG_SINGLE_INSTANCE=1`.

This supersedes #31 with the same protection but a different default to preserve legitimate multi-client MCP usage (multiple Claude Code windows, Claude Desktop + IDE simultaneously, etc.).

Closes #31 (with credit to @Hohlas — see Credits below).

## Why opt-in by default

MCP stdio is one process per client by protocol design. Hard-rejecting the second instance breaks every legitimate multi-client workflow. The lazy-load embedding change in #32 already cuts the per-process memory cost dramatically; this guard is an escape hatch for users who measured a remaining problem and want a hard cap.

## Behavior

| `KNOWLEDGE_RAG_SINGLE_INSTANCE` | Effect |
|---|---|
| unset / `0` / `false` / empty / anything else | **No-op.** No lock file. Multi-client friendly. (default) |
| `1` / `true` / `yes` / `on` (case-insensitive) | Acquire lock; second instance exits with code 75 |

When enabled:
- Creates `<data_dir>/knowledge-rag.lock` with `O_CREAT|O_EXCL` + this PID
- Stale locks (PID gone) auto-recovered on next startup
- `SIGINT`/`SIGTERM` handlers remove lock and re-raise so default disposition fires
- Per-data-dir scope; independent RAGs do not collide

## Files

- `mcp_server/instance_lock.py` (new) — opt-in lock module with signal handlers
- `mcp_server/server.py` — `main()` wraps startup in `single_instance_lock()` (no-op if disabled)
- `tests/test_instance_lock.py` (new) — 12 test cases
- `docs/single-instance.md` (new) — when to use, when NOT, troubleshooting
- `examples/mcp-config-single-instance.json` (new) — sample MCP client config
- `README.md` — troubleshooting section + memory-usage update

## Credits

Original guard concept, reproduction, and lock implementation: **@Hohlas** in #31. Reworked here as opt-in (default off), signal handlers actually wired (the original PR claimed SIGTERM cleanup but had no handlers), expanded test coverage. `Co-Authored-By` trailer in the commit preserves attribution.

## Test plan

- [ ] CI matrix green (Linux + Windows × 3.11 + 3.12)
- [ ] Manual: `knowledge-rag` boots without env var -> no lock file appears
- [ ] Manual: `KNOWLEDGE_RAG_SINGLE_INSTANCE=1 knowledge-rag` then second invocation -> exit 75
- [ ] Manual: kill -9 the first; second startup recovers stale lock and acquires