### PR TITLE
chore(release): v3.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,21 @@ pip install knowledge-rag → restart Claude Code → search_knowledge("your que
 
 ---
 
-## What's New in v3.6.0
+## What's New in v3.8.0
 
-### Multi-Language Code Parsing
+### Lazy-Loaded Embeddings — Cheaper Idle Processes
 
-Language-aware extraction for **C**, **C++**, **JavaScript**, **TypeScript**, and **XML** — functions, classes, structs, interfaces, imports, and namespaces are captured as searchable metadata. Total supported formats: **20**.
+The FastEmbed ONNX model (~200MB resident) now loads on the **first query**, not at startup. Idle `knowledge-rag` processes are now genuinely cheap. Why this matters: MCP stdio is one-process-per-client by protocol — multiple Claude Code windows, Claude Desktop + IDE simultaneously, or review/approval flows that open extra connections all spawn their own processes. Before v3.8.0, every one of them paid the full embedding-model cost up front. Now only processes that actually serve queries load the model. Public API is unchanged.
+
+### Opt-In Single-Instance Guard
+
+For users who measured their setup and want a hard cap of one server per `data_dir`:
+
+```bash
+export KNOWLEDGE_RAG_SINGLE_INSTANCE=1
+```
+
+A second instance exits immediately with code 75. **OFF by default** so multi-client MCP usage continues to work unchanged. Stale-PID recovery + SIGINT/SIGTERM cleanup wired correctly. Full guide in [docs/single-instance.md](docs/single-instance.md). Sample MCP config in [examples/mcp-config-single-instance.json](examples/mcp-config-single-instance.json).
 
 ### 5 Ways to Install
 
@@ -53,6 +63,7 @@ All methods produce the same MCP server. See [Installation](#installation) for f
 
 ### Recent Highlights
 
+- **v3.8.0** — Lazy-load embeddings, opt-in single-instance guard, version sync across PyPI/NPM/Docker
 - **v3.6.0** — Multi-language code parsing (C/C++/JS/TS/XML), NPM wrapper, Docker image, automated release pipeline
 - **v3.5.2** — CUDA DLL auto-discovery from pip packages, graceful GPU→CPU fallback, explicit CPU provider (no CUDA noise when `gpu: false`), BASE_DIR resolution fix for editable installs
 - **v3.5.1** — Remove Python `<3.13` upper bound — 3.13 and 3.14 now supported
@@ -1065,6 +1076,17 @@ A second instance exits immediately with code 75. Default is OFF (multi-client f
 ---
 
 ## Changelog
+
+### v3.8.0 (2026-05-10)
+
+- **NEW**: Lazy-load FastEmbed embedding model (~200MB ONNX runtime). Loads on first query instead of startup — idle `knowledge-rag` processes are now cheap, which matters when MCP stdio clients spawn parallel server processes (multiple Claude Code windows, Claude Desktop + IDE, etc.). Public API unchanged. (#32)
+- **NEW**: Opt-in single-instance guard via `KNOWLEDGE_RAG_SINGLE_INSTANCE=1` env var. **OFF by default** — multi-client MCP usage continues to work unchanged. When enabled, a second server process for the same `data_dir` exits with code 75 (`EX_TEMPFAIL`). Includes stale-PID recovery and SIGINT/SIGTERM handlers. See [docs/single-instance.md](docs/single-instance.md). (#33, original concept by @Hohlas in #31)
+- **NEW**: `examples/mcp-config-single-instance.json` — sample MCP client config for the opt-in guard.
+- **DOCS**: New `docs/single-instance.md` — when to use, when NOT to use, troubleshooting, full activation reference.
+- **DOCS**: README troubleshooting section for "Multiple MCP clients spawn duplicate servers" + memory-usage note for lazy embeddings.
+- **CHORE**: Sync version across `pyproject.toml`, `mcp_server/__init__.py`, and `npm/package.json` (was drifting since v3.5.x).
+- **CHORE**: pytest `tmp_path_retention_count=1` to avoid Windows atexit cleanup race in CI.
+- **ROADMAP**: Tracked v4.0 shared-service architecture (one daemon, many thin MCP clients) as the long-term fix for multi-process resource duplication. (#34)
 
 ### Unreleased
 

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -8,7 +8,7 @@ import sys  # noqa: I001
 _original_stdout = sys.stdout
 sys.stdout = sys.stderr
 
-__version__ = "3.5.2"
+__version__ = "3.8.0"
 __author__ = "Ailton Rocha (Lyon.)"
 
 from .config import Config  # noqa: E402

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-rag",
-  "version": "3.6.2",
+  "version": "3.8.0",
   "description": "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 12 MCP Tools + 20 Format Parsers. Zero external servers.",
   "bin": {
     "knowledge-rag": "./bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "knowledge-rag"
-version = "3.7.0"
+version = "3.8.0"
 description = "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 12 MCP Tools + 20 Format Parsers. Zero external servers."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Release **v3.8.0** — bundles two merged feature PRs and the version sync.

| Channel | Version | How it ships |
|---|---|---|
| PyPI | `knowledge-rag==3.8.0` | `pypa/gh-action-pypi-publish` (Trusted Publishing) |
| NPM | `knowledge-rag@3.8.0` | `npm publish --access public --provenance` (version auto-synced from tag) |
| Docker | `ghcr.io/lyonzin/knowledge-rag:3.8.0` (+ `3.8`, `latest`) | `docker/build-push-action@v7` |

## What it ships

- **#32** Lazy-load FastEmbed embedding model on first query (~200MB cost deferred). Idle MCP processes are now cheap.
- **#33** Opt-in single-instance guard via `KNOWLEDGE_RAG_SINGLE_INSTANCE=1` env var. **Default OFF** — multi-client MCP usage continues unchanged. (Original concept by @Hohlas in #31, full credit preserved.)
- **#34** v4.0 shared-service architecture tracked in roadmap.

## Bumps

- `pyproject.toml`: 3.7.0 -> 3.8.0
- `mcp_server/__init__.py`: 3.5.2 -> 3.8.0 (was drifting; **fixed**)
- `npm/package.json`: 3.6.2 -> 3.8.0 (was drifting; **fixed**)

## CHANGELOG

Updated in `README.md` `## Changelog` section + `## What''s New in v3.8.0` block. Curated entries: NEW (lazy embeddings, opt-in guard, examples, docs), CHORE (version sync, pytest retention), ROADMAP (#34).

## Backwards compatibility

- **Lazy embeddings**: API unchanged, GPU/CPU fallback identical, same log messages emitted on first use instead of startup. Public surface intact.
- **Single-instance guard**: default OFF; users without the env var see exact pre-v3.8.0 behavior.
- **Version sync**: cosmetic (no runtime impact); fixes a multi-year drift.

## Release procedure (after this PR merges)

```
gh release create v3.8.0 \
  --title "v3.8.0 — Lazy embeddings + Opt-in single-instance guard" \
  --notes-from-tag    # or paste curated notes from README CHANGELOG
```

The `release.yml` workflow auto-runs on `release: published` and:
1. Tests on Ubuntu × Python 3.11/3.12
2. Builds sdist + wheel
3. Publishes to PyPI via Trusted Publishing
4. Publishes to NPM with provenance (auto-syncs version from tag)
5. Builds + pushes Docker image to ghcr.io

## Pre-merge checklist

- [x] Versions synced in 3 places
- [x] CHANGELOG entry written
- [x] What''s New refreshed
- [x] All feature PRs merged (#32, #33)
- [x] Documentation in place (`docs/single-instance.md`, `examples/`)
- [ ] **Awaiting Lyon approval** before publishing to PyPI/NPM/Docker