### PR TITLE
fix(embeddings): raise loud on load/embed failures (no silent zero vectors)

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -129,6 +129,18 @@ class QueryCache:
 # =============================================================================
 
 
+class EmbeddingError(RuntimeError):
+    """Raised when embedding generation fails after a successful model load."""
+
+
+class EmbeddingModelLoadError(RuntimeError):
+    """Raised when the embedding model itself cannot be loaded.
+
+    Distinct from EmbeddingError so callers can decide whether to retry
+    (transient runtime failure) or surface a hard configuration problem.
+    """
+
+
 class FastEmbedEmbeddings:
     """
     FastEmbed-based embedding function for ChromaDB (v1.4.0+ compatible).
@@ -190,33 +202,57 @@ class FastEmbedEmbeddings:
         self._gpu = bool(config.gpu_acceleration)
         self._model: Optional[TextEmbedding] = None
         self._load_lock = threading.Lock()
+        # Sticky failure flag: once load fails, subsequent calls re-raise immediately
+        # instead of looping through download/retry. Same pattern as CrossEncoderReranker.
+        self._load_failed: Optional[Exception] = None
 
     def _load_model(self) -> None:
-        """Load the ONNX model on demand. Idempotent and thread-safe."""
+        """Load the ONNX model on demand. Idempotent and thread-safe.
+
+        Raises:
+            EmbeddingModelLoadError: when the underlying ONNX runtime cannot
+                instantiate the model (missing files, hash mismatch, etc.). The
+                exception is sticky — subsequent calls raise the same error
+                without retrying so callers do not loop through HF downloads.
+        """
         if self._model is not None:
             return
+        if self._load_failed is not None:
+            raise EmbeddingModelLoadError(
+                f"Embedding model previously failed to load: {self._load_failed}"
+            ) from self._load_failed
         with self._load_lock:
             if self._model is not None:  # double-checked under the lock
                 return
+            if self._load_failed is not None:
+                raise EmbeddingModelLoadError(
+                    f"Embedding model previously failed to load: {self._load_failed}"
+                ) from self._load_failed
             kwargs = dict(self._init_kwargs)
-            if self._gpu:
-                self._setup_cuda_dll_paths()
-                kwargs["providers"] = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-                print(f"[INFO] Loading embedding model: {self.model_name} ({self._dim}D) [GPU accelerated]...")
-                try:
-                    self._model = TextEmbedding(**kwargs)
-                    print("[INFO] Embedding model loaded successfully [GPU]")
-                    return
-                except (ValueError, RuntimeError) as e:
-                    print(f"[WARN] GPU init failed ({e}), falling back to CPU...")
+            try:
+                if self._gpu:
+                    self._setup_cuda_dll_paths()
+                    kwargs["providers"] = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+                    print(f"[INFO] Loading embedding model: {self.model_name} ({self._dim}D) [GPU accelerated]...")
+                    try:
+                        self._model = TextEmbedding(**kwargs)
+                        print("[INFO] Embedding model loaded successfully [GPU]")
+                    except (ValueError, RuntimeError) as e:
+                        print(f"[WARN] GPU init failed ({e}), falling back to CPU...")
+                        kwargs["providers"] = ["CPUExecutionProvider"]
+                        self._model = TextEmbedding(**kwargs)
+                        print("[INFO] Embedding model loaded successfully [CPU fallback]")
+                else:
                     kwargs["providers"] = ["CPUExecutionProvider"]
+                    print(f"[INFO] Loading embedding model: {self.model_name} ({self._dim}D)...")
                     self._model = TextEmbedding(**kwargs)
-                    print("[INFO] Embedding model loaded successfully [CPU fallback]")
-                    return
-            kwargs["providers"] = ["CPUExecutionProvider"]
-            print(f"[INFO] Loading embedding model: {self.model_name} ({self._dim}D)...")
-            self._model = TextEmbedding(**kwargs)
-            print("[INFO] Embedding model loaded successfully")
+                    print("[INFO] Embedding model loaded successfully")
+            except Exception as exc:
+                # ONNXRuntimeError, FileNotFoundError, etc. — record and re-raise loud
+                self._load_failed = exc
+                self._model = None
+                print(f"[ERROR] Embedding model load FAILED: {exc}", file=sys.stderr)
+                raise EmbeddingModelLoadError(f"Failed to load embedding model: {exc}") from exc
 
     def __call__(self, input: List[str]) -> List[List[float]]:
         """
@@ -224,17 +260,38 @@ class FastEmbedEmbeddings:
 
         ChromaDB embedding_function interface: __call__(input: List[str]) -> List[List[float]]
         FastEmbed.embed() returns a generator, so we consume it into a list.
+
+        Raises:
+            EmbeddingModelLoadError: when the model could not be loaded.
+            EmbeddingError: when embedding generation fails after a successful load.
+
+        Behavior note (changed in v3.8.1):
+            Previously this method swallowed any exception and returned vectors
+            of zeros (``[[0.0]*dim for _ in input]``). That silently corrupted
+            the index — ChromaDB stored zero vectors as document embeddings,
+            ``count()`` returned the right number of chunks, smart-reindex
+            would skip them as "already indexed", and queries returned garbage
+            similarity scores. Failures are now LOUD: the caller (ChromaDB
+            ``add()``, MCP search tool, etc.) sees the real error and can
+            surface it to the user.
         """
         if not input:
             return []
 
-        self._load_model()
+        self._load_model()  # may raise EmbeddingModelLoadError
         try:
             embeddings = list(self._model.embed(input))
-            return [emb.tolist() for emb in embeddings]
-        except Exception as e:
-            print(f"[WARN] Embedding failed: {e}")
-            return [[0.0] * self._dim for _ in input]
+        except Exception as exc:
+            print(f"[ERROR] Embedding generation FAILED: {exc}", file=sys.stderr)
+            raise EmbeddingError(f"Embedding generation failed: {exc}") from exc
+
+        # Sanity check: model returned the right number of vectors with the right dim
+        if len(embeddings) != len(input):
+            raise EmbeddingError(f"Embedding count mismatch: expected {len(input)}, got {len(embeddings)}")
+        result = [emb.tolist() for emb in embeddings]
+        if result and len(result[0]) != self._dim:
+            raise EmbeddingError(f"Embedding dim mismatch: expected {self._dim}, got {len(result[0])}")
+        return result
 
     def name(self) -> str:
         """Return embedding function name (required by ChromaDB v1.4.0+)"""

--- a/tests/test_lazy_embeddings.py
+++ b/tests/test_lazy_embeddings.py
@@ -1,8 +1,9 @@
-"""Tests for lazy initialization of FastEmbedEmbeddings (v3.8.0+).
+"""Tests for lazy initialization + loud-fail behavior of FastEmbedEmbeddings.
 
-The embedding model is heavy (~200MB resident). We defer the load to the
-first real call so idle MCP server processes stay cheap. This matters when
-multiple stdio clients spawn parallel knowledge-rag processes.
+v3.8.0 introduced lazy loading: the ~200MB ONNX model is constructed on the
+first call instead of in __init__. v3.8.1 added LOUD failures: previously
+this class swallowed any exception and returned vectors of zeros, which
+silently corrupted the index. Both behaviors are tested here.
 """
 
 from __future__ import annotations
@@ -10,12 +11,31 @@ from __future__ import annotations
 import threading
 from unittest.mock import MagicMock, patch
 
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
 
 def _make_embedder():
     """Build a FastEmbedEmbeddings instance without triggering ONNX load."""
     from mcp_server.server import FastEmbedEmbeddings
 
     return FastEmbedEmbeddings()
+
+
+def _fake_model_returning(dim: int):
+    """A MagicMock TextEmbedding that returns one ``dim``-D vector per input."""
+    fake = MagicMock()
+    fake.embed.side_effect = lambda texts: iter([np.zeros(dim, dtype=np.float32) for _ in texts])
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Lazy-load behavior (v3.8.0)
+# ---------------------------------------------------------------------------
 
 
 def test_init_does_not_load_model():
@@ -27,24 +47,20 @@ def test_init_does_not_load_model():
 
 
 def test_first_call_loads_model():
-    """The first __call__ must materialize the model exactly once."""
-    fake_model = MagicMock()
-    fake_model.embed.return_value = iter([])
-    with patch("mcp_server.server.TextEmbedding", return_value=fake_model) as mock_te:
+    """The first __call__ with non-empty input must materialize the model once."""
+    with patch("mcp_server.server.TextEmbedding", return_value=_fake_model_returning(384)) as mock_te:
         emb = _make_embedder()
         assert emb._model is None
-        emb([])  # empty input short-circuits before embedding, but _load is fine to skip
-        # Empty input returns early — confirm by triggering with real text
+        emb([])  # empty short-circuits before load
+        assert emb._model is None
         emb(["hello"])
-        assert emb._model is fake_model
+        assert emb._model is not None
         assert mock_te.call_count == 1
 
 
 def test_second_call_reuses_model():
     """Subsequent calls must NOT reload the model (idempotent _load_model)."""
-    fake_model = MagicMock()
-    fake_model.embed.side_effect = lambda texts: iter([])
-    with patch("mcp_server.server.TextEmbedding", return_value=fake_model) as mock_te:
+    with patch("mcp_server.server.TextEmbedding", return_value=_fake_model_returning(384)) as mock_te:
         emb = _make_embedder()
         emb(["one"])
         emb(["two"])
@@ -54,9 +70,7 @@ def test_second_call_reuses_model():
 
 def test_embed_query_triggers_load():
     """embed_query path must also trigger lazy load."""
-    fake_model = MagicMock()
-    fake_model.embed.return_value = iter([])
-    with patch("mcp_server.server.TextEmbedding", return_value=fake_model) as mock_te:
+    with patch("mcp_server.server.TextEmbedding", return_value=_fake_model_returning(384)) as mock_te:
         emb = _make_embedder()
         assert emb._model is None
         emb.embed_query("query text")
@@ -65,9 +79,7 @@ def test_embed_query_triggers_load():
 
 def test_embed_documents_triggers_load():
     """embed_documents path must also trigger lazy load."""
-    fake_model = MagicMock()
-    fake_model.embed.return_value = iter([])
-    with patch("mcp_server.server.TextEmbedding", return_value=fake_model) as mock_te:
+    with patch("mcp_server.server.TextEmbedding", return_value=_fake_model_returning(384)) as mock_te:
         emb = _make_embedder()
         assert emb._model is None
         emb.embed_documents(["doc"])
@@ -75,20 +87,13 @@ def test_embed_documents_triggers_load():
 
 
 def test_concurrent_first_call_loads_once():
-    """Two threads racing on the first call must trigger exactly ONE load.
-
-    The lock-protected _load_model is single-entry, so even a slow model
-    construction won't cause a duplicate init. We hold the first init briefly
-    to ensure the second thread arrives during the load and observes the lock.
-    """
-    fake_model = MagicMock()
-    fake_model.embed.return_value = iter([])
+    """Two threads racing on the first call must trigger exactly ONE load."""
     init_started = threading.Event()
     release_init = threading.Event()
+    fake_model = _fake_model_returning(384)
 
     def slow_init(**kwargs):
         init_started.set()
-        # Block here so the second thread has time to race on the lock
         release_init.wait(timeout=2)
         return fake_model
 
@@ -103,16 +108,120 @@ def test_concurrent_first_call_loads_once():
         t1 = threading.Thread(target=worker)
         t2 = threading.Thread(target=worker)
         t1.start()
-        # Wait for thread 1 to be inside slow_init (holding the lock)
         assert init_started.wait(timeout=2), "first thread never entered slow_init"
         t2.start()
-        # Give t2 a moment to hit the lock
         threading.Event().wait(0.05)
-        # Release t1's init; t2 should then exit fast via the double-checked guard
         release_init.set()
         t1.join(timeout=5)
         t2.join(timeout=5)
 
-        # Even with two threads racing, the model is constructed exactly once
         assert mock_te.call_count == 1
         assert len(results) == 2
+
+
+# ---------------------------------------------------------------------------
+# Loud-fail behavior (v3.8.1)
+# ---------------------------------------------------------------------------
+
+
+def test_load_failure_raises_loud():
+    """A model that cannot be constructed must raise EmbeddingModelLoadError.
+
+    Regression for v3.8.0 silent corruption: previously the embedder swallowed
+    load failures, returned zero vectors, and ChromaDB happily stored garbage.
+    """
+    from mcp_server.server import EmbeddingModelLoadError
+
+    with patch("mcp_server.server.TextEmbedding", side_effect=FileNotFoundError("model_optimized.onnx")):
+        emb = _make_embedder()
+        with pytest.raises(EmbeddingModelLoadError) as ei:
+            emb(["hello"])
+        # Original cause preserved for diagnostics
+        assert isinstance(ei.value.__cause__, FileNotFoundError)
+
+
+def test_load_failure_is_sticky():
+    """After a load failure, subsequent calls re-raise WITHOUT retrying the load.
+
+    Avoids the user-visible "frozen" behavior where each query triggers a
+    fresh HuggingFace download attempt that hits rate limits.
+    """
+    from mcp_server.server import EmbeddingModelLoadError
+
+    with patch("mcp_server.server.TextEmbedding", side_effect=FileNotFoundError("model_optimized.onnx")) as mock_te:
+        emb = _make_embedder()
+        with pytest.raises(EmbeddingModelLoadError):
+            emb(["a"])
+        with pytest.raises(EmbeddingModelLoadError):
+            emb(["b"])
+        with pytest.raises(EmbeddingModelLoadError):
+            emb(["c"])
+        # First call attempted the load; subsequent calls did NOT retry
+        assert mock_te.call_count == 1
+
+
+def test_embed_runtime_failure_raises_loud():
+    """Model loaded but ``embed()`` raises -> EmbeddingError (NOT silent zeros)."""
+    from mcp_server.server import EmbeddingError
+
+    fake = MagicMock()
+    fake.embed.side_effect = RuntimeError("ONNX runtime crashed")
+    with patch("mcp_server.server.TextEmbedding", return_value=fake):
+        emb = _make_embedder()
+        with pytest.raises(EmbeddingError):
+            emb(["text"])
+
+
+def test_embed_count_mismatch_raises():
+    """Model returns wrong number of vectors -> EmbeddingError."""
+    from mcp_server.server import EmbeddingError
+
+    fake = MagicMock()
+    fake.embed.side_effect = lambda texts: iter([np.zeros(384, dtype=np.float32)])  # always 1
+    with patch("mcp_server.server.TextEmbedding", return_value=fake):
+        emb = _make_embedder()
+        with pytest.raises(EmbeddingError, match="count mismatch"):
+            emb(["a", "b", "c"])
+
+
+def test_embed_dim_mismatch_raises():
+    """Model returns wrong dimensionality -> EmbeddingError."""
+    from mcp_server.server import EmbeddingError
+
+    fake = _fake_model_returning(128)  # config expects 384
+    with patch("mcp_server.server.TextEmbedding", return_value=fake):
+        emb = _make_embedder()
+        with pytest.raises(EmbeddingError, match="dim mismatch"):
+            emb(["text"])
+
+
+def test_empty_input_does_not_trigger_load_or_raise():
+    """Empty input must short-circuit before model load (cheap no-op)."""
+    with patch("mcp_server.server.TextEmbedding", side_effect=FileNotFoundError("would crash")) as mock_te:
+        emb = _make_embedder()
+        result = emb([])
+        assert result == []
+        mock_te.assert_not_called()
+
+
+def test_does_not_return_zero_vectors_silently():
+    """Pure regression guard: under no failure path do we ever return zeros silently.
+
+    The whole point of v3.8.1 — if anything goes wrong, the caller MUST see an
+    exception. Returning ``[[0.0]*dim, ...]`` was the bug.
+    """
+    from mcp_server.server import EmbeddingError, EmbeddingModelLoadError
+
+    # Path 1: load fails
+    with patch("mcp_server.server.TextEmbedding", side_effect=Exception("boom")):
+        emb = _make_embedder()
+        with pytest.raises(EmbeddingModelLoadError):
+            emb(["a"])
+
+    # Path 2: load OK, embed fails
+    fake = MagicMock()
+    fake.embed.side_effect = Exception("boom mid-embed")
+    with patch("mcp_server.server.TextEmbedding", return_value=fake):
+        emb2 = _make_embedder()
+        with pytest.raises(EmbeddingError):
+            emb2(["a"])


### PR DESCRIPTION
## Summary

Critical bug: ``FastEmbedEmbeddings.__call__`` was swallowing any exception and returning vectors of zeros. This silently corrupted the index whenever the ONNX model was unavailable.

**Pre-existing in master, not introduced by v3.8.0** — but v3.8.0 lazy-load EXPANDED the impact (load failures now happen at query time, and silent-zeros made them invisible).

## How it manifested

Live repro found while validating v3.8.0 install:

1. ``models_cache/models--qdrant--bge-small-en-v1.5-onnx-q/`` had 0-byte ``model_optimized.onnx`` (HF download interrupted)
2. ``reindex_documents`` reported ``indexed: 215`` but ``chunks_added: 0`` — embed call failed silently, returned zeros, ChromaDB ``add()`` accepted them
3. ``search_knowledge(category="aar")`` returned 0 results with no error message
4. ``[WARN] Embedding failed: NO_SUCHFILE`` was the only clue, hidden in stderr

## Root cause

`mcp_server/server.py:232-237` (before fix):
```python
try:
    embeddings = list(self._model.embed(input))
    return [emb.tolist() for emb in embeddings]
except Exception as e:
    print(f"[WARN] Embedding failed: {e}")
    return [[0.0] * self._dim for _ in input]   # ← silent corruption
```

ChromaDB stored zeros, ``count()`` returned right number, smart-reindex skipped them as "already indexed", queries returned garbage similarity. Failure mode invisible to the user.

## Fix

- New ``EmbeddingError`` + ``EmbeddingModelLoadError`` exception classes
- ``_load_model()`` catches load failures, records ``_load_failed`` (sticky flag), raises ``EmbeddingModelLoadError``. Subsequent calls re-raise WITHOUT retrying the HF download — avoids "frozen" UX where each query triggers fresh rate-limited download
- ``__call__`` no longer returns zeros: any ``embed()`` exception → ``EmbeddingError``. Added count + dim mismatch sanity checks.

## Behavior change for callers

| Site | Before | After |
|---|---|---|
| ``index_all`` | counted as ``indexed=1, chunks=0`` (corrupted) | exception caught at line 771, ``errors+=1``, doc NOT marked indexed → retried next reindex |
| ``search_knowledge`` semantic path | got ``[]`` from embed | gets exception caught at line 1010, falls through to BM25 with ``[WARN]`` |
| ``search_knowledge`` w/ broken model | "0 results" silently | ``[WARN] Semantic search failed: ...`` visible in stderr, BM25 still works |

No public API change. Same exit semantics for happy path.

## Tests

`tests/test_lazy_embeddings.py` expanded from 6 to 13 cases:

- ``test_load_failure_raises_loud``
- ``test_load_failure_is_sticky`` (no HF retry storm)
- ``test_embed_runtime_failure_raises_loud``
- ``test_embed_count_mismatch_raises``
- ``test_embed_dim_mismatch_raises``
- ``test_empty_input_does_not_trigger_load_or_raise``
- ``test_does_not_return_zero_vectors_silently`` (regression guard for the whole class of bug)
- 6 existing lazy-load tests adjusted to provide proper-shape mock vectors

Local run: 13/13 passed in 1.51s.

## Test plan

- [ ] CI matrix green (Linux + Windows × 3.11 + 3.12)
- [ ] Manual repro: corrupt ``models_cache/`` (e.g. ``Set-Content -Path ...\model_optimized.onnx -Value $null``), reindex → see ``errors > 0`` instead of ``indexed > 0`` with ``chunks_added: 0``
- [ ] Manual: query with broken model → semantic falls back to BM25 with visible warning, no hang

## Versioning

This will ship as **v3.8.1 hotfix** in a follow-up release PR after merge.