### PR TITLE
chore(release): v3.8.1 hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,6 +1077,14 @@ A second instance exits immediately with code 75. Default is OFF (multi-client f
 
 ## Changelog
 
+### v3.8.1 (2026-05-10) — hotfix
+
+- **FIX (critical)**: `FastEmbedEmbeddings.__call__` no longer returns vectors of zeros when the ONNX model fails to load or `embed()` raises. The previous behavior silently corrupted the index — ChromaDB stored zero embeddings, `count()` reported normal numbers, smart-reindex skipped the bad chunks, and queries returned garbage scores with no error visible. Now raises `EmbeddingModelLoadError` / `EmbeddingError`. (#36)
+- **FIX**: Sticky `_load_failed` flag — after a load failure, subsequent calls re-raise immediately instead of looping through HuggingFace download attempts (was the "frozen query" UX in v3.8.0).
+- **NEW**: Sanity checks in `__call__` — embed count and dim mismatches raise `EmbeddingError` instead of silently returning malformed vectors.
+- **TEST**: 7 new regression cases in `tests/test_lazy_embeddings.py`, including `test_does_not_return_zero_vectors_silently` as a guard for the whole class of bug.
+- **NOTE**: This is a pre-existing bug in master, not introduced by v3.8.0. v3.8.0 lazy-load expanded the impact (failures moved to query time). All v3.8.0 users should upgrade.
+
 ### v3.8.0 (2026-05-10)
 
 - **NEW**: Lazy-load FastEmbed embedding model (~200MB ONNX runtime). Loads on first query instead of startup — idle `knowledge-rag` processes are now cheap, which matters when MCP stdio clients spawn parallel server processes (multiple Claude Code windows, Claude Desktop + IDE, etc.). Public API unchanged. (#32)

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -8,7 +8,7 @@ import sys  # noqa: I001
 _original_stdout = sys.stdout
 sys.stdout = sys.stderr
 
-__version__ = "3.8.0"
+__version__ = "3.8.1"
 __author__ = "Ailton Rocha (Lyon.)"
 
 from .config import Config  # noqa: E402

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-rag",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 12 MCP Tools + 20 Format Parsers. Zero external servers.",
   "bin": {
     "knowledge-rag": "./bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "knowledge-rag"
-version = "3.8.0"
+version = "3.8.1"
 description = "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 12 MCP Tools + 20 Format Parsers. Zero external servers."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Hotfix release v3.8.1 — ships the critical silent-zeros bug fix from #36.

## What it ships

- **#36 fix(embeddings): raise loud on load/embed failures** — `FastEmbedEmbeddings.__call__` no longer returns zero vectors on failure. Pre-existing bug in master, expanded impact by v3.8.0 lazy-load.

## Bumps

- `pyproject.toml`: 3.8.0 -> 3.8.1
- `mcp_server/__init__.py`: 3.8.0 -> 3.8.1
- `npm/package.json`: 3.8.0 -> 3.8.1

## Why this is urgent (PATCH not MINOR)

Any v3.8.0 user with:
- Interrupted HuggingFace model download
- Corrupted `models_cache/` (e.g. 0-byte files)
- HF rate-limit during first lazy load

...will index garbage zeros silently and see "0 results" with no error. The fix is binary-compatible, no API change, no config change required.

## Backwards compatibility

- Public API: unchanged
- Default behavior: preserved
- New exceptions are additive (subclasses of `RuntimeError`)
- Callers that already wrap embed calls in `try/except` continue to work; the `[WARN] Semantic search failed:` already-existing path catches the new exception cleanly

## Release procedure

After merge: `gh release create v3.8.1` -> `release.yml` auto-publishes:
- PyPI 3.8.1 (Trusted Publishing)
- NPM 3.8.1 (provenance, version auto-sync from tag)
- Docker `ghcr.io/lyonzin/knowledge-rag:3.8.1` + `3.8` + `latest`

Awaiting Lyon approval before tag/publish.