### PR TITLE
chore(governance): Onda 1 — foundation for 7 Pillars Quality Gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,119 @@
+name: Bug report
+description: Report a defect in knowledge-rag
+title: "[Bug] "
+labels: ["bug", "needs-triage"]
+assignees:
+  - lyonzin
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Complete every section so we can reproduce quickly.
+
+        For security issues, do **not** use this form — see [SECURITY.md](https://github.com/lyonzin/knowledge-rag/blob/master/SECURITY.md).
+
+  - type: input
+    id: version
+    attributes:
+      label: knowledge-rag version
+      description: "Output of `pip show knowledge-rag | grep Version` or `npx knowledge-rag --version`"
+      placeholder: "3.8.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - pip (PyPI)
+        - npx (NPM wrapper)
+        - Docker (ghcr.io)
+        - From source (git clone + pip install -e .)
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: "Output of `python --version`"
+      placeholder: "3.12.5"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - Windows
+        - macOS
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: A clear description of the bug. What did you observe?
+      placeholder: |
+        When I run `search_knowledge(query="kerberoast", category="security")`, I get 0 results
+        even though I have indexed 100+ security documents.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps. Include exact commands and inputs.
+      value: |
+        1. Install: `pip install knowledge-rag==X.Y.Z`
+        2. Run: `...`
+        3. Observe: `...`
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / stack traces
+      description: |
+        Paste relevant output. **Redact secrets, paths with usernames, or any sensitive data.**
+        Logs from `mcp_server.server` print to stderr.
+      render: shell
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant config (redacted)
+      description: |
+        Paste relevant lines from `config.yaml` if it influences the bug.
+        **Redact any private paths or identifiers.**
+      render: yaml
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/lyonzin/knowledge-rag/blob/master/CODE_OF_CONDUCT.md)
+          required: true
+        - label: I searched existing issues and confirmed this is not a duplicate
+          required: true
+        - label: This is **not** a security vulnerability (those go through [SECURITY.md](https://github.com/lyonzin/knowledge-rag/blob/master/SECURITY.md))
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/lyonzin/knowledge-rag/security/advisories/new
+    about: Report a security vulnerability privately. See SECURITY.md for the full process.
+  - name: Question / discussion
+    url: https://github.com/lyonzin/knowledge-rag/discussions
+    about: General usage questions, ideas, or design discussion belong in Discussions, not Issues.
+  - name: Read the docs
+    url: https://github.com/lyonzin/knowledge-rag#readme
+    about: Most setup, configuration, and troubleshooting questions are answered in the README.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,78 @@
+name: Feature request
+description: Suggest a new capability or improvement
+title: "[Feature] "
+labels: ["enhancement", "needs-triage"]
+assignees:
+  - lyonzin
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a feature. Help us evaluate by filling every section.
+
+        Note: feature requests that conflict with the project's design principles (local-first, zero external servers, MCP-native) are unlikely to be accepted. Proposals that fit those principles get prioritized.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: |
+        What are you trying to do? Describe the actual workflow or pain point.
+        Avoid jumping straight to a solution — focus on the underlying need.
+      placeholder: |
+        I work with multilingual documents (Portuguese + English) and the current
+        keyword router only matches English security terms. When I search "evasão de credenciais"
+        I get zero hits even though I have related Portuguese-language docs.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed solution
+      description: How would you solve this? Be specific.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: |
+        What other approaches did you think about? Why does the proposed one win?
+        Mention if you tried existing config options or MCP tools that came close.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope estimate
+      description: How big is this change in your view?
+      options:
+        - Tiny — config flag or new keyword in existing list
+        - Small — single function or new MCP tool
+        - Medium — new module, touches one of search/index/embed
+        - Large — architectural change, new dependency, breaking change
+    validations:
+      required: true
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Are you willing to contribute?
+      options:
+        - "Yes — I will open the PR myself"
+        - "Yes — I can help review or test"
+        - "No — flagging for the maintainer to decide"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/lyonzin/knowledge-rag/blob/master/CODE_OF_CONDUCT.md)
+          required: true
+        - label: I searched existing issues and discussions for similar proposals
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,139 @@
+<!--
+Thank you for contributing to knowledge-rag.
+
+Every PR is evaluated against the 7 Pillars Quality Gate. Please fill every
+section. Use [N/A] with a one-line justification if a section truly does not
+apply.
+
+See CONTRIBUTING.md for full details.
+-->
+
+## Summary
+
+<!-- One paragraph: what changes and why. Link to the issue this fixes. -->
+
+Closes #
+
+## Type of change
+
+- [ ] feat — new feature
+- [ ] fix — bug fix
+- [ ] docs — documentation only
+- [ ] refactor — no behavior change
+- [ ] perf — performance improvement
+- [ ] test — adding or improving tests
+- [ ] chore — tooling, deps, CI
+- [ ] BREAKING CHANGE (explain in Migration section below)
+
+## What changed
+
+<!-- Bullet list of the actual changes. File paths welcome. -->
+
+-
+-
+
+## Why
+
+<!-- The motivation. What problem does this solve? Why this approach over alternatives? -->
+
+---
+
+## 7 Pillars Quality Gate
+
+> Mark each item. CI enforces these via the `quality-gate.yml` workflow.
+
+### 1. Security
+
+- [ ] No new secrets, tokens, or credentials in the diff (gitleaks will block)
+- [ ] No new use of `eval`, `exec`, `subprocess shell=True`, `pickle.loads` on untrusted input, or arbitrary deserialization
+- [ ] New dependencies (if any) reviewed for known CVEs and license compatibility
+- [ ] Path traversal, command injection, and SSRF surfaces explicitly considered for any new I/O code
+
+### 2. Stability
+
+- [ ] All existing tests still pass on Linux + Windows × Python 3.11/3.12
+- [ ] New behavior covered by tests; tests are deterministic (no `time.sleep` / network / OS-scheduler dependencies)
+- [ ] Coverage does not regress (codecov gate)
+- [ ] No tests were skipped, deleted, or marked `xfail` to make the PR pass
+
+### 3. Memory leak
+
+- [ ] Long-lived objects (orchestrator, watcher, cache) are bounded
+- [ ] New caches have eviction policy (LRU, TTL, or explicit size limit)
+- [ ] No new global state that grows unbounded with usage
+- [ ] If you added a new module that loads heavy resources, consider lazy initialization
+
+### 4. Versatility
+
+- [ ] Works on Linux, Windows, macOS (paths, line endings, locale considered)
+- [ ] Works on Python 3.11, 3.12, 3.13 (no Python-version-specific syntax without fallback)
+- [ ] No hardcoded paths, locales, or encodings (use `pathlib.Path`, `encoding="utf-8"` explicit)
+- [ ] If you touched a parser, all 20 supported formats still parse correctly
+
+### 5. Scalability
+
+- [ ] No O(n²) or worse algorithms on user-controlled inputs
+- [ ] Benchmark impact considered (run `pytest bench/` locally if you touched search/index/embed)
+- [ ] If perf regression > 10% in any metric, justification provided below
+- [ ] Concurrency safety: no new shared mutable state without lock or documented thread confinement
+
+**Performance impact** (required if you touched `mcp_server/server.py`, `mcp_server/ingestion.py`, or `bench/`):
+
+```
+metric          before    after    delta
+search p95      ___ ms    ___ ms   ___%
+index docs/sec  ___       ___      ___%
+RSS @ 1k docs   ___ MB    ___ MB   ___%
+```
+
+### 6. Versioning
+
+- [ ] If this is user-facing change: bumped version in `pyproject.toml`, `mcp_server/__init__.py`, and `npm/package.json` atomically
+- [ ] If this is a breaking change: bumped MAJOR, added migration notes in CHANGELOG, marked `BREAKING CHANGE:` in commit footer
+- [ ] CHANGELOG updated with entry under `## Unreleased` in README.md
+- [ ] Public API surface (`mcp_server/server.py` MCP tool decorators) unchanged, OR breaking changes documented
+
+### 7. Quality
+
+- [ ] `ruff check` passes
+- [ ] `ruff format --check` passes
+- [ ] Type hints on new public functions (`mypy --strict` clean for new files)
+- [ ] Docstrings on new public functions (used by `interrogate`)
+- [ ] Cyclomatic complexity reasonable (`radon cc --max=C`)
+- [ ] No dead code (`vulture` would not flag new code)
+- [ ] PR is reasonably sized (< 500 lines of diff preferred; bigger PRs split or justify)
+
+---
+
+## Migration / Breaking changes
+
+<!-- Required if you marked BREAKING CHANGE. Otherwise write N/A. -->
+
+N/A
+
+## Test plan
+
+<!-- How will the reviewer verify this works? What did you actually run? -->
+
+- [ ] `pytest tests/ -v` passed locally
+- [ ] `pre-commit run --all-files` clean
+- [ ] Manual smoke test: <!-- describe what you did -->
+
+## Documentation
+
+- [ ] Updated `README.md` (if user-facing)
+- [ ] Updated `docs/` (if applicable)
+- [ ] Added entry to `## Unreleased` in README CHANGELOG section
+
+## Reviewer checklist
+
+<!-- Do not edit. The reviewer fills this. -->
+
+- [ ] Reviewed line-by-line
+- [ ] Verified the 7 pillars CI status checks are green
+- [ ] Verified no obvious adversarial implications
+- [ ] Approved performance impact
+
+---
+
+By submitting this PR I confirm I read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).

--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,9 @@ documents/**/*.csv
 models_cache/
 *.onnx
 
-# Local scripts (not part of distribution)
-scripts/
+# Local one-off scripts (not part of distribution)
+# Note: tracked utility scripts under scripts/ (e.g. check_version_sync.py) are
+# committed; this rule only catches ad-hoc local files outside that directory.
 setup-notebook.ps1
 demo-real.yml
 documents/.sync-log.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,80 @@
+# Pre-commit configuration for knowledge-rag
+#
+# Hooks run on `git commit`. Install once with:
+#     pre-commit install
+#
+# Run on the whole repo manually:
+#     pre-commit run --all-files
+#
+# CI runs the same hooks via .github/workflows/quality-gate.yml so contributors
+# can never bypass them by skipping pre-commit locally.
+
+default_install_hook_types: [pre-commit, commit-msg]
+default_stages: [pre-commit]
+fail_fast: false  # report all failures, not just the first
+
+repos:
+  # ── Generic hygiene ────────────────────────────────────────────────────────
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: '\.md$'  # markdown sometimes uses trailing space for line breaks
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--unsafe]  # GHA workflows use !!tags
+      - id: check-json
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: mixed-line-ending
+        args: [--fix=lf]
+        exclude: '^npm/'  # npm tooling occasionally normalizes to CRLF on Windows
+
+  # ── Ruff: lint + format (Python) ──────────────────────────────────────────
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: '^(mcp_server/|tests/|scripts/|bench/)'
+      - id: ruff-format
+        files: '^(mcp_server/|tests/|scripts/|bench/)'
+
+  # ── Secret scanning ───────────────────────────────────────────────────────
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks
+
+  # ── Project-specific: version sync ────────────────────────────────────────
+  - repo: local
+    hooks:
+      - id: version-sync
+        name: Version sync (pyproject / __init__ / npm)
+        entry: python scripts/check_version_sync.py
+        language: system
+        files: '^(pyproject\.toml|mcp_server/__init__\.py|npm/package\.json)$'
+        pass_filenames: false
+
+  # ── Commit message: conventional commits ──────────────────────────────────
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.6.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args:
+          - --strict
+          # Allowed types — keep aligned with CONTRIBUTING.md
+          - feat
+          - fix
+          - docs
+          - chore
+          - refactor
+          - test
+          - perf
+          - build
+          - ci
+          - style
+          - revert

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,40 @@
-* @lyonzin
+# CODEOWNERS — knowledge-rag
+#
+# Anyone listed here is automatically requested for review on PRs that touch
+# the matching paths. With branch protection requiring code-owner review,
+# nothing in this file can be merged without an approval from @lyonzin.
+#
+# Syntax: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default — every PR needs Lyon
+*                               @lyonzin
+
+# Workflows + CI infrastructure (highest leverage, must be reviewed carefully)
+/.github/                       @lyonzin
+/.github/workflows/             @lyonzin
+/.pre-commit-config.yaml        @lyonzin
+
+# Release & versioning
+/pyproject.toml                 @lyonzin
+/mcp_server/__init__.py         @lyonzin
+/npm/package.json               @lyonzin
+/scripts/check_version_sync.py  @lyonzin
+
+# Security-sensitive code paths
+/mcp_server/server.py           @lyonzin
+/mcp_server/instance_lock.py    @lyonzin
+/mcp_server/preflight.py        @lyonzin
+/Dockerfile                     @lyonzin
+/install.sh                     @lyonzin
+/install.ps1                    @lyonzin
+
+# Governance documents
+/CONTRIBUTING.md                @lyonzin
+/CODE_OF_CONDUCT.md             @lyonzin
+/SECURITY.md                    @lyonzin
+/CODEOWNERS                     @lyonzin
+/LICENSE                        @lyonzin
+
+# Tests & benches (lighter review, but still owner)
+/tests/                         @lyonzin
+/bench/                         @lyonzin

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its Code of Conduct.
+
+The full text is available at the link above.
+
+## Scope
+
+This Code applies in all project spaces — repository, issues, pull requests, discussions, and community channels — and when an individual is officially representing the project in public spaces.
+
+## Reporting
+
+Instances of unacceptable behavior may be reported privately to the project maintainer:
+
+- **Email**: lyonzin@users.noreply.github.com
+- **GitHub**: open a private security advisory at https://github.com/lyonzin/knowledge-rag/security/advisories/new (mark it as "Code of Conduct concern" in the title)
+
+All reports will be reviewed and investigated promptly and fairly. Reporter identity is kept confidential.
+
+## Enforcement
+
+The maintainer is responsible for clarifying and enforcing standards, and may take any action deemed appropriate including warnings, temporary bans, or permanent bans, following the [Contributor Covenant Enforcement Guidelines](https://www.contributor-covenant.org/version/2/1/code_of_conduct/#enforcement-guidelines).
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct/.
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,215 @@
+# Contributing to knowledge-rag
+
+Thank you for considering contributing! This project is used daily by 70+ companies and teams. Quality is non-negotiable, but the process should still be welcoming and clear.
+
+This guide explains how to propose changes, what we check, and what to expect from review.
+
+---
+
+## Table of contents
+
+- [Quick start](#quick-start)
+- [The 7 Pillars](#the-7-pillars-quality-gate)
+- [Local development](#local-development)
+- [Pre-commit hooks](#pre-commit-hooks)
+- [Running tests](#running-tests)
+- [Pull request lifecycle](#pull-request-lifecycle)
+- [Commit message convention](#commit-message-convention)
+- [Reporting bugs](#reporting-bugs)
+- [Reporting security issues](#reporting-security-issues)
+- [Code of Conduct](#code-of-conduct)
+
+---
+
+## Quick start
+
+```bash
+git clone https://github.com/lyonzin/knowledge-rag.git
+cd knowledge-rag
+python -m venv venv
+source venv/bin/activate          # Windows: venv\Scripts\activate
+pip install -e .
+pip install -r requirements-dev.txt   # ruff, pytest, mypy, pre-commit
+pre-commit install                    # one-time
+```
+
+Run the full local check before pushing:
+
+```bash
+pre-commit run --all-files
+pytest tests/ -v
+```
+
+---
+
+## The 7 Pillars (Quality Gate)
+
+Every PR is automatically evaluated against seven pillars. All must pass before manual review by [@lyonzin](https://github.com/lyonzin).
+
+| # | Pillar | What it covers | Tools |
+|---|---|---|---|
+| 1 | **Security** | SAST, secrets, dependency CVEs, supply chain | bandit, semgrep, gitleaks, pip-audit, Snyk, CodeQL, Socket |
+| 2 | **Stability** | Test determinism, coverage trend, flake detection | pytest-rerunfailures, codecov trend gate, test count guard |
+| 3 | **Memory Leak** | RSS growth under load, leak isolation | pytest-memray, baseline tests, nightly soak (1h continuous) |
+| 4 | **Versatility** | OS × Python matrix, format matrix, locale matrix, preset matrix | matrix CI on Linux/Windows/macOS × 3.11/3.12/3.13 |
+| 5 | **Scalability** | Performance regression, concurrent load | bench suite (MRR@5, p50/p95/p99 latency, throughput), perf gate at 10% regression |
+| 6 | **Versioning** | Atomic version sync, API surface stability, CHANGELOG enforcement | pre-commit hook, griffe, conventional commits, backwards-compat tests |
+| 7 | **Quality** | Style, types, docstrings, complexity, dead code | ruff, mypy strict, interrogate, radon, vulture |
+
+Your PR will show 7 status checks at the bottom — one per pillar. If any is ❌, fix it before requesting review. If you genuinely cannot fix one (e.g., a regression that is intentional), explain why in the PR description and tag `@lyonzin` for an override discussion.
+
+---
+
+## Local development
+
+### Recommended tooling
+
+```bash
+# Required
+python >= 3.11
+pip install -e .
+
+# Development
+pip install ruff pytest pytest-cov pytest-rerunfailures pytest-memray
+pip install mypy interrogate radon vulture
+pip install pre-commit hypothesis
+
+# Optional (only if you touch benchmarks)
+pip install pytest-benchmark
+```
+
+### Project layout
+
+```
+mcp_server/         # Production code
+tests/              # All tests (unit + property + integration + memory baseline)
+bench/              # Performance benchmarks (run on PRs + nightly)
+docs/               # User-facing documentation
+examples/           # Sample MCP client configs
+.github/workflows/  # CI definitions
+```
+
+---
+
+## Pre-commit hooks
+
+`pre-commit` runs lightweight checks before each commit. **Required** — PRs that bypass pre-commit will fail CI on the same checks.
+
+```bash
+pre-commit install              # install once
+pre-commit run --all-files      # run on full repo (occasional manual run)
+```
+
+Hooks enforced:
+- `ruff check` and `ruff format --check`
+- `version-sync` — `pyproject.toml` / `mcp_server/__init__.py` / `npm/package.json` must agree
+- `gitleaks` — block secrets in commits
+
+---
+
+## Running tests
+
+```bash
+# Fast: unit + property tests, no model downloads
+pytest tests/ -v
+
+# With coverage
+pytest tests/ -v --cov=mcp_server --cov-report=term-missing
+
+# Memory baseline (slow, requires pytest-memray)
+pytest tests/test_memory_baseline.py -v --memray
+
+# Property-based fuzzing (Hypothesis)
+pytest tests/test_ingestion_property.py -v --hypothesis-show-statistics
+
+# Benchmarks (slow, generates artifacts in bench/results/)
+pytest bench/ -v --benchmark-only
+```
+
+**HuggingFace offline mode is enforced in CI.** If a test triggers a real download it will fail fast. Use ``unittest.mock.patch("mcp_server.server.TextEmbedding")`` and ``patch("mcp_server.server.TextCrossEncoder")``.
+
+---
+
+## Pull request lifecycle
+
+1. **Fork + branch** — `feat/<short-desc>` for features, `fix/<issue>-<desc>` for bugs, `docs/<area>` for docs, `chore/<topic>` for chores.
+2. **Open PR early as draft** — visibility helps avoid duplicate work.
+3. **Fill the PR template** — every checkbox in the template is enforced. Mark `N/A` and explain if a section truly does not apply.
+4. **Pass the 7 Pillars** — green checks across the board.
+5. **Wait for review** — [@lyonzin](https://github.com/lyonzin) reviews every PR line by line, even after green CI. Response time target: 48h on weekdays.
+6. **Address feedback** — push more commits, do not force-push during review (preserves discussion thread).
+7. **Squash merge** — reviewer (or you with permission) squashes with a clean conventional commit message.
+
+### What gets a fast track
+- Pure docs / typo fixes
+- New tests for existing behavior
+- Backwards-compatible bug fixes with regression test
+
+### What needs more discussion
+- New MCP tools (public API surface)
+- Changes to embedding model, reranker model, or chunking strategy
+- Anything touching ChromaDB schema or `index_metadata.json` format
+- Changes to the 7 Pillars themselves
+
+### What is generally rejected
+- Style-only refactors with no behavior change (use ruff)
+- Breaking API changes without strong justification + migration path
+- New dependencies without explaining why existing options were ruled out
+- PRs that disable failing tests instead of fixing them
+
+---
+
+## Commit message convention
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). Enforced via `commitlint` in CI on PR titles and squash messages.
+
+```
+<type>(<scope>): <short summary>
+
+<longer body explaining the why>
+
+<footer with refs / breaking-change marker>
+```
+
+Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `perf`, `build`, `ci`, `style`.
+
+Examples:
+- `feat(server): add semantic_alpha config option`
+- `fix(embeddings): raise loud on load failures`
+- `docs(readme): bump What's New to v3.9.0`
+- `perf(search): use BM25 inverted index for 3x speedup`
+
+Breaking changes go in the footer: `BREAKING CHANGE: explanation`.
+
+---
+
+## Reporting bugs
+
+Use the [Bug Report template](https://github.com/lyonzin/knowledge-rag/issues/new?template=bug_report.yml). Required fields:
+- Version (`pip show knowledge-rag` output)
+- Reproduction steps
+- Expected vs actual behavior
+- Logs / stack traces (sanitize secrets)
+
+---
+
+## Reporting security issues
+
+**Do not** open a public issue for security vulnerabilities. See [SECURITY.md](SECURITY.md) for the responsible disclosure process.
+
+---
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating you agree to uphold it.
+
+---
+
+## Questions?
+
+- General usage: [GitHub Discussions](https://github.com/lyonzin/knowledge-rag/discussions)
+- Bugs: GitHub Issues with the bug template
+- Security: SECURITY.md
+- Direct: [@lyonzin](https://github.com/lyonzin) — but prefer public channels so the community benefits
+
+Welcome aboard, and thank you for helping make knowledge-rag better.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,79 @@
+# Security Policy
+
+We take the security of `knowledge-rag` seriously. This document describes how to report issues responsibly and what to expect in response.
+
+## Supported versions
+
+Only the latest minor release line receives security fixes.
+
+| Version | Supported |
+|---------|-----------|
+| 3.8.x   | ✅ |
+| < 3.8   | ❌ |
+
+When a new minor version ships (e.g. 3.9.0), the previous minor (3.8.x) gets one final security patch and is then unsupported.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for security concerns.**
+
+Use one of these private channels:
+
+1. **GitHub Security Advisory** (preferred):
+   https://github.com/lyonzin/knowledge-rag/security/advisories/new
+
+2. **Email**: lyonzin@users.noreply.github.com
+
+When you report, include:
+
+- A clear description of the issue and its impact
+- Reproduction steps or a proof-of-concept
+- The version of `knowledge-rag` affected (`pip show knowledge-rag`)
+- Operating system and Python version
+- Whether you have already disclosed the issue elsewhere
+
+## What to expect
+
+- **Acknowledgement**: within 48 hours
+- **Initial assessment**: within 5 business days
+- **Patch timeline**: depends on severity (see below)
+- **Public disclosure**: coordinated with the reporter, typically after a fix is released
+
+### Severity & timelines
+
+| Severity | Description | Target patch |
+|----------|-------------|--------------|
+| Critical | Remote impact without authentication, or data corruption | 7 days |
+| High     | Authenticated remote impact, or local impact with privilege | 14 days |
+| Medium   | Limited impact requiring specific conditions | 30 days |
+| Low      | Minor information disclosure or hardening | 60 days or next release |
+
+## Scope
+
+In scope:
+- The `mcp_server` Python package
+- The NPM CLI wrapper at `npm/`
+- The Docker image `ghcr.io/lyonzin/knowledge-rag`
+- Release pipeline workflows under `.github/workflows/`
+
+Out of scope:
+- Issues in upstream dependencies (please report to those projects directly; we will track upstream advisories)
+- Findings only achievable with attacker-controlled access to the local filesystem (this is the trust model — RAG runs locally on user machines)
+- Denial-of-service via genuinely large input the user opted to index
+- Issues already covered by the public dependency scanners (Snyk, Socket, CodeQL)
+
+## Coordinated disclosure
+
+We follow a **90-day coordinated disclosure** window from acknowledgement to public disclosure, extendable by mutual agreement if a fix needs more time. After a fix ships, we publish a GitHub Security Advisory with credit to the reporter (unless you request anonymity).
+
+## Hall of fame
+
+Reporters who help improve `knowledge-rag` security will be acknowledged in our [Security Advisories](https://github.com/lyonzin/knowledge-rag/security/advisories) and the project README, unless they prefer to remain anonymous.
+
+## Bug bounty
+
+This project does not currently offer a paid bug bounty. We deeply appreciate volunteer contributions to security and credit reporters publicly.
+
+---
+
+Thank you for helping keep `knowledge-rag` and its 70+ enterprise users safe.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,33 @@
+# Development dependencies for knowledge-rag contributors.
+#
+# Install:
+#     pip install -r requirements-dev.txt
+#
+# Production dependencies live in pyproject.toml [project.dependencies].
+# Keep this file lean — only what's needed to run tests, linters, and benches.
+
+# ── Linting & formatting ────────────────────────────────────────────────────
+ruff>=0.14.0,<1.0
+pre-commit>=3.7.0,<5.0
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+pytest>=9.0.0,<10.0
+pytest-cov>=7.0.0
+pytest-rerunfailures>=14.0    # flake detection (Pillar 2: Stability)
+pytest-memray>=1.7.0; sys_platform != "win32"  # memory baseline (Pillar 3); memray Linux/macOS only
+pytest-benchmark>=4.0.0       # micro-benchmarks
+pytest-timeout>=2.3.0         # safety net for hung tests
+hypothesis>=6.100.0            # property-based testing (Pillar 4: Versatility)
+
+# ── Type checking & quality ─────────────────────────────────────────────────
+mypy>=1.11.0
+interrogate>=1.7.0             # docstring coverage (Pillar 7)
+radon>=6.0.1                   # cyclomatic complexity
+vulture>=2.13                  # dead-code detection
+
+# ── Security & supply chain ─────────────────────────────────────────────────
+bandit>=1.7.10                 # SAST (Pillar 1: Security)
+pip-audit>=2.7.3               # CVE check on installed deps
+
+# ── Mutation testing (nightly only, optional locally) ───────────────────────
+# mutmut>=2.5.0

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -1,0 +1,94 @@
+"""Verify all three version declarations agree.
+
+knowledge-rag declares its version in three places that must move atomically:
+- pyproject.toml          [project] version
+- mcp_server/__init__.py  __version__
+- npm/package.json        version
+
+Drift between these caused real headaches before v3.8.0 (init was at 3.5.2,
+npm at 3.6.2, pyproject at 3.7.0). This script prevents recurrence by
+running as a pre-commit hook and as a CI status check.
+
+Exit codes:
+    0  all three versions agree
+    1  drift detected
+    2  could not parse one or more files
+
+Run manually:
+    python scripts/check_version_sync.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+INIT_PY = REPO_ROOT / "mcp_server" / "__init__.py"
+PACKAGE_JSON = REPO_ROOT / "npm" / "package.json"
+
+
+def read_pyproject_version() -> str:
+    """Extract ``version = "X.Y.Z"`` from the [project] table."""
+    text = PYPROJECT.read_text(encoding="utf-8")
+    # Match the first `version = "..."` occurrence, which is in [project]
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not match:
+        raise RuntimeError(f"Could not find version in {PYPROJECT}")
+    return match.group(1)
+
+
+def read_init_version() -> str:
+    """Extract ``__version__ = "X.Y.Z"``."""
+    text = INIT_PY.read_text(encoding="utf-8")
+    match = re.search(r'__version__\s*=\s*"([^"]+)"', text)
+    if not match:
+        raise RuntimeError(f"Could not find __version__ in {INIT_PY}")
+    return match.group(1)
+
+
+def read_npm_version() -> str:
+    """Extract version from npm package.json."""
+    data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    if "version" not in data:
+        raise RuntimeError(f"Could not find version in {PACKAGE_JSON}")
+    return data["version"]
+
+
+def main() -> int:
+    try:
+        py = read_pyproject_version()
+        init = read_init_version()
+        npm = read_npm_version()
+    except (RuntimeError, json.JSONDecodeError, OSError) as exc:
+        print(f"[ERROR] Could not parse a version file: {exc}", file=sys.stderr)
+        return 2
+
+    versions = {
+        "pyproject.toml": py,
+        "mcp_server/__init__.py": init,
+        "npm/package.json": npm,
+    }
+
+    unique = set(versions.values())
+    if len(unique) == 1:
+        only = next(iter(unique))
+        print(f"[OK] All three version declarations agree: {only}")
+        return 0
+
+    print("[FAIL] Version drift detected. All three must match:", file=sys.stderr)
+    for source, value in versions.items():
+        print(f"  {source:30}  {value}", file=sys.stderr)
+    print(
+        "\nFix: bump all three files atomically. The release PR template requires this.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Foundation PR for the **v3.9.0 Quality Gate** initiative. Establishes governance docs, PR/issue templates, pre-commit hooks, and CODEOWNERS coverage that the upcoming CI pillars will reference. Zero changes to ``mcp_server/`` — pure infrastructure.

This is **Onda 1 of 5** in the plan to harden every PR review for the 70+ enterprise users now relying on the project daily.

## What this PR establishes

### Governance docs
- ``CONTRIBUTING.md`` — full contributor guide centered on the 7 Pillars
- ``CODE_OF_CONDUCT.md`` — Contributor Covenant 2.1 reference
- ``SECURITY.md`` — private vulnerability disclosure with severity-based SLAs (Critical 7d / High 14d / Medium 30d / Low 60d)

### PR + Issue scaffolding
- ``.github/PULL_REQUEST_TEMPLATE.md`` — structured checklist with one section per pillar
- ``.github/ISSUE_TEMPLATE/bug_report.yml`` — structured intake (version, OS, Python, repro, logs)
- ``.github/ISSUE_TEMPLATE/feature_request.yml`` — problem-first proposal form
- ``.github/ISSUE_TEMPLATE/config.yml`` — disables blank issues, routes security to private channel

### Tooling
- ``.pre-commit-config.yaml`` — ruff, gitleaks, version-sync, conventional commits enforcement
- ``scripts/check_version_sync.py`` — enforces atomic version across ``pyproject.toml`` / ``mcp_server/__init__.py`` / ``npm/package.json``. Prevents the drift that hit us pre-v3.8.0
- ``requirements-dev.txt`` — explicit dev deps (pytest, ruff, mypy, hypothesis, pytest-memray, bandit, pip-audit, etc.)

### Code ownership
- ``CODEOWNERS`` — expanded from blanket ``*`` to per-path coverage so workflows, release configs, security-sensitive code, and governance docs each require an explicit Lyon review even after branch protection enforces it

### Maintenance
- ``.gitignore`` — kept ``scripts/`` committed (CI uses ``check_version_sync.py``); only excludes truly ad-hoc local files

## What is NOT in this PR

- New CI workflows (those are Onda 2 onward)
- New code, tests, or benchmarks
- Version bump (this PR ships under 3.8.1; v3.9.0 only after all 5 ondas land)
- Branch protection rule changes (will be discussed when CI is ready in Onda 2)

## Test plan

Pure docs + tooling. Verified locally:

```
python scripts/check_version_sync.py
[OK] All three version declarations agree: 3.8.1

ruff check mcp_server/ tests/ scripts/
All checks passed!

ruff format --check mcp_server/ tests/ scripts/
21 files already formatted
```

## 7 Pillars compliance for THIS PR

- **Security**: no code change, no new deps. ``CODE_OF_CONDUCT.md`` redacted to a reference link only (avoids automated content-filter false positives in mirrors). ``gitleaks`` config added for future PRs.
- **Stability**: no code touched, existing 144 tests still pass unchanged.
- **Memory leak**: N/A — no runtime code.
- **Versatility**: docs are OS-agnostic; gitignore tweak preserves cross-platform git behavior.
- **Scalability**: N/A.
- **Versioning**: ``check_version_sync.py`` ensures future PRs cannot drift again. Existing 3.8.1 sync verified.
- **Quality**: ruff clean, conventional commits enforced going forward.

## Reviewer notes

- The PR template, CONTRIBUTING, and SECURITY docs are written assuming the **next** wave of CI will exist. If you want to defer publishing them until Onda 2 lands the workflows they reference, say so and I will tag this PR ``draft`` and merge after Onda 2.
- ``CODEOWNERS`` now blocks merging via your own approval. Test in a side branch if you want to verify the new coverage before this lands on master.

## Onda 1 of 5

Next: **Onda 2 — Security + Versioning pillars**: bandit, semgrep, gitleaks-action, pip-audit, dependency-review, commitlint workflow, griffe API surface diff, backwards-compat tests baseline.