### PR TITLE
ci(quality-gate): Onda 3 — Quality + Versatility pillars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,40 @@ jobs:
         run: ruff format --check mcp_server/ tests/
 
   test:
-    name: Test (Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    name: Test (Python ${{ matrix.python-version }}, ${{ matrix.os }})${{ matrix.experimental && ' [experimental]' || '' }}
     needs: lint
     runs-on: ${{ matrix.os }}
+    # Pillar 4 (Versatility): 3 OS x 3 Python = 9 combos.
+    # Stable combos (Linux+Windows x 3.11+3.12) must pass.
+    # Experimental combos (macOS, Python 3.13) report visibly but do not
+    # block the gate yet — fastembed/onnxruntime wheels for those targets
+    # are still catching up. Promotion to required happens in a future PR
+    # once two consecutive nightlies are green.
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
         os: [ubuntu-latest, windows-latest]
+        python-version: ["3.11", "3.12"]
+        experimental: [false]
+        include:
+          # ── macOS x 3.11/3.12 (experimental) ──
+          - os: macos-latest
+            python-version: "3.11"
+            experimental: true
+          - os: macos-latest
+            python-version: "3.12"
+            experimental: true
+          # ── Python 3.13 across all OS (experimental) ──
+          - os: ubuntu-latest
+            python-version: "3.13"
+            experimental: true
+          - os: windows-latest
+            python-version: "3.13"
+            experimental: true
+          - os: macos-latest
+            python-version: "3.13"
+            experimental: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -210,6 +210,178 @@ jobs:
         run: pytest tests/test_backwards_compat.py -v
 
   # ════════════════════════════════════════════════════════════════════════
+  # PILLAR 4: VERSATILITY
+  # ════════════════════════════════════════════════════════════════════════
+
+  versatility-presets:
+    name: "Pillar 4 — Preset matrix"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install minimal deps for YAML parsing
+        shell: bash
+        run: pip install pytest pyyaml
+      - name: Run preset structural validation
+        shell: bash
+        run: pytest tests/test_presets.py -v
+
+  versatility-locale:
+    name: "Pillar 4 — Locale matrix"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install package
+        shell: bash
+        run: |
+          pip install -e .
+          pip install pytest
+      - name: Run locale + encoding tests
+        shell: bash
+        env:
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
+          HF_HUB_DISABLE_PROGRESS_BARS: "1"
+        run: pytest tests/test_locale.py -v
+
+  versatility-formats:
+    name: "Pillar 4 — Format smoke matrix"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install package
+        shell: bash
+        run: |
+          pip install -e .
+          pip install pytest
+      - name: Run format smoke tests
+        shell: bash
+        env:
+          HF_HUB_OFFLINE: "1"
+          TRANSFORMERS_OFFLINE: "1"
+          HF_HUB_DISABLE_PROGRESS_BARS: "1"
+        run: pytest tests/test_format_smoke.py -v
+
+  # ════════════════════════════════════════════════════════════════════════
+  # PILLAR 7: QUALITY
+  # ════════════════════════════════════════════════════════════════════════
+
+  mypy:
+    name: "Pillar 7 — mypy strict (gradual)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install mypy + package
+        shell: bash
+        run: |
+          pip install mypy
+          pip install -e .
+      - name: Run mypy on annotated modules + scripts
+        shell: bash
+        # Gradual rollout: only modules already fully annotated. As legacy
+        # code earns annotations, append paths here.
+        run: mypy mcp_server/instance_lock.py mcp_server/preflight.py scripts/
+
+  interrogate:
+    name: "Pillar 7 — Docstring coverage"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install interrogate
+      - name: Verify docstring coverage >= 80%
+        shell: bash
+        run: interrogate -c pyproject.toml mcp_server/
+
+  radon:
+    name: "Pillar 7 — Cyclomatic complexity"
+    runs-on: ubuntu-latest
+    # Report-only for now: we know Config / orchestrator.query are D/E
+    # (legacy hot-spots). Visibility helps the maintainer prioritize
+    # refactors without blocking unrelated PRs.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install radon
+      - name: Report C+ complexity blocks
+        shell: bash
+        run: |
+          echo "## Radon Cyclomatic Complexity (C and higher)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          radon cc mcp_server/ -a -nc | tee -a $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          # Fail only when a NEW block is rated D+ — placeholder for now.
+          # The followup PR will diff against master baseline.
+
+  vulture:
+    name: "Pillar 7 — Dead code (vulture)"
+    runs-on: ubuntu-latest
+    continue-on-error: true   # report-only initially
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install vulture
+      - name: Scan for dead code (high-confidence only)
+        shell: bash
+        run: |
+          vulture mcp_server/ scripts/ .vulture_whitelist.py --min-confidence 80 \
+            | tee vulture-report.txt || true
+          if [ -s vulture-report.txt ] && grep -v "^$" vulture-report.txt > /dev/null; then
+            echo "## Vulture findings (informational)" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat vulture-report.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
+
+  pr-size:
+    name: "Pillar 7 — PR size guard"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    continue-on-error: true   # warn-only by design
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Measure code change size (excluding docs/lockfiles)
+        shell: bash
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          changed=$(git diff --numstat "${base}" "${head}" \
+            -- 'mcp_server/**' 'scripts/**' 'tests/**' 'bench/**' \
+            ':!*.md' ':!*.json' ':!*.lock' ':!*.txt' ':!*.yaml' ':!*.yml' \
+            | awk '{added+=$1; removed+=$2} END {print added+removed}')
+          changed=${changed:-0}
+          echo "## PR size: ${changed} lines changed (code only)" >> $GITHUB_STEP_SUMMARY
+          if [ "${changed}" -gt 500 ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ This PR exceeds 500 lines of code change. Consider splitting into smaller PRs for easier review." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "(Warning only — this does not block merge.)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "✅ PR size is reasonable." >> $GITHUB_STEP_SUMMARY
+          fi
+
+  # ════════════════════════════════════════════════════════════════════════
   # SUMMARY
   # ════════════════════════════════════════════════════════════════════════
 
@@ -218,13 +390,22 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
+      # Pillar 1 — Security
       - bandit
       - semgrep
       - pip-audit
       - gitleaks
+      # Pillar 4 — Versatility
+      - versatility-presets
+      - versatility-locale
+      - versatility-formats
+      # Pillar 6 — Versioning
       - version-sync
       - api-surface
       - backwards-compat
+      # Pillar 7 — Quality (blocking)
+      - mypy
+      - interrogate
     steps:
       - name: Aggregate results
         shell: bash
@@ -237,9 +418,14 @@ jobs:
           echo "| 1 Security | Semgrep | ${{ needs.semgrep.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 1 Security | pip-audit | ${{ needs.pip-audit.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 1 Security | Gitleaks | ${{ needs.gitleaks.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 4 Versatility | Preset matrix | ${{ needs.versatility-presets.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 4 Versatility | Locale matrix | ${{ needs.versatility-locale.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 4 Versatility | Format matrix | ${{ needs.versatility-formats.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 6 Versioning | Version sync | ${{ needs.version-sync.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 6 Versioning | API surface | ${{ needs.api-surface.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 6 Versioning | Backwards-compat | ${{ needs.backwards-compat.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 7 Quality | mypy strict | ${{ needs.mypy.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 7 Quality | Docstring coverage | ${{ needs.interrogate.result }} |" >> $GITHUB_STEP_SUMMARY
           # `skipped` is acceptable (PR-only jobs running on push events skip cleanly).
           # `cancelled` is acceptable (concurrency cancel of older runs).
           # Only `failure` blocks the gate.
@@ -248,9 +434,14 @@ jobs:
             "${{ needs.semgrep.result }}" \
             "${{ needs.pip-audit.result }}" \
             "${{ needs.gitleaks.result }}" \
+            "${{ needs.versatility-presets.result }}" \
+            "${{ needs.versatility-locale.result }}" \
+            "${{ needs.versatility-formats.result }}" \
             "${{ needs.version-sync.result }}" \
             "${{ needs.api-surface.result }}" \
-            "${{ needs.backwards-compat.result }}"; do
+            "${{ needs.backwards-compat.result }}" \
+            "${{ needs.mypy.result }}" \
+            "${{ needs.interrogate.result }}"; do
             if [[ "$r" == "failure" ]]; then
               echo "" >> $GITHUB_STEP_SUMMARY
               echo "❌ One or more pillars failed. Address the issues above before review." >> $GITHUB_STEP_SUMMARY
@@ -258,4 +449,4 @@ jobs:
             fi
           done
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ All Quality Gate pillars passed." >> $GITHUB_STEP_SUMMARY
+          echo "✅ All blocking Quality Gate pillars passed." >> $GITHUB_STEP_SUMMARY

--- a/.vulture_whitelist.py
+++ b/.vulture_whitelist.py
@@ -1,0 +1,19 @@
+"""Whitelist for false-positive findings from vulture.
+
+Each "unused" item below is referenced externally (signal handler
+signature, ChromaDB callback, watchdog event, MCP framework dispatch,
+etc.) so vulture cannot see the consumer. Vulture executes this file
+to exercise the names — we deliberately reference them so the dead-code
+report stays clean.
+
+Run with:
+    vulture mcp_server/ scripts/ .vulture_whitelist.py --min-confidence 80
+"""
+
+# Signal handler signature requires (signum, frame); vulture sees `frame` as unused
+# but Python's signal module passes both arguments unconditionally.
+_dummy_frame = object()
+
+
+def _signal_handler_stub(signum, frame):  # noqa: ARG001
+    return signum, frame

--- a/mcp_server/instance_lock.py
+++ b/mcp_server/instance_lock.py
@@ -155,7 +155,7 @@ def single_instance_lock() -> Iterator[Optional[Path]]:
     # Wire signal handlers so SIGINT/SIGTERM cleanup the lock before exit
     previous_handlers: dict[int, object] = {}
 
-    def _signal_cleanup(signum: int, frame) -> None:
+    def _signal_cleanup(signum: int, frame: object) -> None:
         _remove_if_ours(lock_path)
         # Restore original handler and re-raise so default action runs
         prev = previous_handlers.get(signum, signal.SIG_DFL)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,3 +118,36 @@ source = ["mcp_server"]
 [tool.coverage.report]
 show_missing = true
 fail_under = 35
+
+# ── mypy: strict gradual rollout (Pillar 7) ─────────────────────────────────
+# Strict mode is enabled GLOBALLY but with a per-module exclusion list while
+# we incrementally annotate the legacy modules. The CI job runs strict on the
+# allowlist below; new modules are added as they earn full annotations.
+[tool.mypy]
+python_version = "3.11"
+strict = true
+show_error_codes = true
+warn_unused_configs = true
+warn_unreachable = true
+ignore_missing_imports = true   # third-party libs (chromadb, fastembed, etc.) often lack stubs
+
+# ── interrogate: docstring coverage (Pillar 7) ──────────────────────────────
+[tool.interrogate]
+fail-under = 80
+verbose = 1
+quiet = false
+exclude = [
+    "tests",
+    "bench",
+    "scripts",
+    "build",
+    "dist",
+    "venv",
+    ".venv",
+]
+ignore-init-method = true
+ignore-init-module = true
+ignore-magic = true
+ignore-property-decorators = true
+ignore-private = true
+ignore-semiprivate = true

--- a/scripts/check_api_surface.py
+++ b/scripts/check_api_surface.py
@@ -161,7 +161,7 @@ def collect_package_surface() -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _diff_function(name: str, old: dict, new: dict, breaks: list[str]) -> None:
+def _diff_function(name: str, old: dict[str, Any], new: dict[str, Any], breaks: list[str]) -> None:
     old_args = old.get("args", [])
     new_args = new.get("args", [])
 
@@ -193,7 +193,7 @@ def _diff_function(name: str, old: dict, new: dict, breaks: list[str]) -> None:
         breaks.append(f"{name}: async/sync flipped")
 
 
-def diff_surfaces(old_surface: dict, new_surface: dict) -> list[str]:
+def diff_surfaces(old_surface: dict[str, Any], new_surface: dict[str, Any]) -> list[str]:
     breaks: list[str] = []
     old_modules = old_surface.get("modules", {})
     new_modules = new_surface.get("modules", {})

--- a/scripts/check_version_sync.py
+++ b/scripts/check_version_sync.py
@@ -56,7 +56,10 @@ def read_npm_version() -> str:
     data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
     if "version" not in data:
         raise RuntimeError(f"Could not find version in {PACKAGE_JSON}")
-    return data["version"]
+    version = data["version"]
+    if not isinstance(version, str):
+        raise RuntimeError(f"npm version field has wrong type: {type(version).__name__}")
+    return version
 
 
 def main() -> int:

--- a/tests/fixtures/formats/sample.c
+++ b/tests/fixtures/formats/sample.c
@@ -1,0 +1,14 @@
+/* Format smoke fixture for the C parser. */
+#include <stdio.h>
+
+struct Config {
+    int value;
+};
+
+int compute(int x, int y) {
+    return x + y;
+}
+
+int main(void) {
+    return 0;
+}

--- a/tests/fixtures/formats/sample.cpp
+++ b/tests/fixtures/formats/sample.cpp
@@ -1,0 +1,14 @@
+// Format smoke fixture for the C++ parser.
+#include <vector>
+#include <string>
+
+class Engine {
+public:
+    Engine() = default;
+    void start();
+};
+
+int main() {
+    Engine engine;
+    return 0;
+}

--- a/tests/fixtures/formats/sample.csv
+++ b/tests/fixtures/formats/sample.csv
@@ -1,0 +1,4 @@
+id,name,role,score
+1,Alice,Admin,95
+2,Bob,Editor,87
+3,Carol,Viewer,72

--- a/tests/fixtures/formats/sample.h
+++ b/tests/fixtures/formats/sample.h
@@ -1,0 +1,11 @@
+/* Format smoke fixture for the C/C++ header parser. */
+#ifndef SAMPLE_H
+#define SAMPLE_H
+
+struct Config {
+    int value;
+};
+
+int compute(int x, int y);
+
+#endif

--- a/tests/fixtures/formats/sample.ipynb
+++ b/tests/fixtures/formats/sample.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# Format smoke fixture (Jupyter)\n",
+    "\n",
+    "This notebook validates the IPYNB parser."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def square(x):\n",
+    "    return x * x\n",
+    "\n",
+    "\n",
+    "result = square(7)\n",
+    "print(result)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/fixtures/formats/sample.js
+++ b/tests/fixtures/formats/sample.js
@@ -1,0 +1,12 @@
+// Format smoke fixture for the JavaScript parser.
+import { useState } from "react";
+
+export function fetchData(url) {
+    return fetch(url).then((r) => r.json());
+}
+
+export class DataService {
+    constructor(endpoint) {
+        this.endpoint = endpoint;
+    }
+}

--- a/tests/fixtures/formats/sample.json
+++ b/tests/fixtures/formats/sample.json
@@ -1,0 +1,12 @@
+{
+    "name": "smoke fixture",
+    "version": "1.0",
+    "items": [
+        {"id": 1, "label": "alpha"},
+        {"id": 2, "label": "beta"}
+    ],
+    "config": {
+        "enabled": true,
+        "threshold": 0.85
+    }
+}

--- a/tests/fixtures/formats/sample.jsx
+++ b/tests/fixtures/formats/sample.jsx
@@ -1,0 +1,11 @@
+// Format smoke fixture for the React JSX parser.
+import React, { useState } from "react";
+
+export function Counter({ initial }) {
+    const [count, setCount] = useState(initial);
+    return (
+        <button onClick={() => setCount(count + 1)}>
+            Count: {count}
+        </button>
+    );
+}

--- a/tests/fixtures/formats/sample.md
+++ b/tests/fixtures/formats/sample.md
@@ -1,0 +1,9 @@
+# Format smoke fixture (Markdown)
+
+## Section A
+
+Sample content for the markdown parser to extract.
+
+## Section B
+
+Second section to validate header-aware chunking.

--- a/tests/fixtures/formats/sample.py
+++ b/tests/fixtures/formats/sample.py
@@ -1,0 +1,10 @@
+"""Format smoke fixture for the Python parser."""
+
+
+def hello(name: str) -> str:
+    return f"Hello, {name}"
+
+
+class SampleClass:
+    def method(self) -> int:
+        return 42

--- a/tests/fixtures/formats/sample.ts
+++ b/tests/fixtures/formats/sample.ts
@@ -1,0 +1,16 @@
+// Format smoke fixture for the TypeScript parser.
+import type { Router } from "express";
+
+interface AppConfig {
+    port: number;
+    host: string;
+}
+
+enum Status {
+    Active,
+    Inactive,
+}
+
+export function createRouter(): Router {
+    return {} as Router;
+}

--- a/tests/fixtures/formats/sample.tsx
+++ b/tests/fixtures/formats/sample.tsx
@@ -1,0 +1,11 @@
+// Format smoke fixture for the React TSX parser.
+import React, { useState } from "react";
+
+interface CounterProps {
+    initial: number;
+}
+
+export function Counter({ initial }: CounterProps): JSX.Element {
+    const [count, setCount] = useState<number>(initial);
+    return <span>{count}</span>;
+}

--- a/tests/fixtures/formats/sample.txt
+++ b/tests/fixtures/formats/sample.txt
@@ -1,0 +1,4 @@
+Format smoke fixture for the plain text parser.
+
+This file contains a simple paragraph used to confirm that the text
+parser produces at least one chunk.

--- a/tests/fixtures/formats/sample.xml
+++ b/tests/fixtures/formats/sample.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://example.com/schema">
+    <name>smoke-fixture</name>
+    <version>1.0</version>
+    <modules>
+        <module id="a">alpha</module>
+        <module id="b">beta</module>
+    </modules>
+</project>

--- a/tests/test_format_smoke.py
+++ b/tests/test_format_smoke.py
@@ -1,0 +1,80 @@
+"""Format smoke matrix — every supported parser produces at least one chunk.
+
+Pillar 4: Versatility — guarantee that the 12 text-based formats we
+ship parsers for keep producing chunks across every release.
+
+Binary formats (PDF, DOCX, XLSX, PPTX) are exercised by their dedicated
+tests in test_ingestion.py — they need real binary fixtures the parser
+can stream, which is more involved than a smoke check.
+
+Each fixture in tests/fixtures/formats/ becomes one parametrized test
+run. Adding a fixture for a new format here automatically extends the
+matrix without touching the test code.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mcp_server.ingestion import DocumentParser
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "formats"
+
+# Formats expected to parse and yield at least one chunk on the smoke fixture
+EXPECTED_FORMATS = {
+    ".md",
+    ".txt",
+    ".py",
+    ".json",
+    ".csv",
+    ".c",
+    ".h",
+    ".cpp",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".xml",
+    ".ipynb",
+}
+
+
+@pytest.fixture(
+    params=sorted(p for p in FIXTURES_DIR.iterdir() if p.suffix in EXPECTED_FORMATS),
+    ids=lambda p: p.suffix,
+)
+def fixture_path(request):
+    """Yield each format fixture so each format gets its own test run."""
+    return request.param
+
+
+def test_format_parses_to_at_least_one_chunk(fixture_path):
+    """Every supported text format must yield ``chunks`` after parsing."""
+    parser = DocumentParser()
+    doc = parser.parse_file(fixture_path)
+    assert doc is not None, f"{fixture_path.name}: parse returned None on smoke fixture"
+    assert doc.chunks, f"{fixture_path.name}: parser produced zero chunks"
+    # Every chunk should carry non-empty content
+    for idx, chunk in enumerate(doc.chunks):
+        assert chunk.content.strip(), f"{fixture_path.name}: chunk #{idx} content is empty/whitespace"
+
+
+def test_all_text_formats_have_a_smoke_fixture():
+    """Releasing without a smoke fixture for every supported text format is a regression."""
+    present = {p.suffix for p in FIXTURES_DIR.iterdir() if p.is_file()}
+    missing = EXPECTED_FORMATS - present
+    assert not missing, (
+        f"Missing smoke fixture(s) under tests/fixtures/formats/ for: {sorted(missing)}. "
+        f"Add one short example file per missing extension to keep the matrix complete."
+    )
+
+
+def test_format_metadata_attached(fixture_path):
+    """Parsed document must carry its source path and detected format suffix."""
+    parser = DocumentParser()
+    doc = parser.parse_file(fixture_path)
+    assert doc is not None
+    assert doc.source == fixture_path
+    assert doc.format == fixture_path.suffix, f"{fixture_path.name}: doc.format='{doc.format}' does not match suffix"

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -1,0 +1,184 @@
+"""Locale and encoding versatility tests.
+
+Pillar 4: Versatility — guarantee the parser does not crash or silently
+drop content when faced with realistic non-ASCII inputs that 70+ enterprise
+users routinely throw at us:
+
+- BOM-prefixed UTF-8 (Windows Notepad / Excel CSV exports)
+- Filenames with accents and spaces (Brazilian Portuguese, French, German)
+- Mixed-script content (Cyrillic, Greek, CJK)
+- LF / CRLF line endings on the same input
+
+Excludes here are deliberate:
+- We do NOT test embedding behavior on non-English text — that belongs to
+  the multilingual feature roadmap, not a regression test.
+- We do NOT exercise the FastEmbed model — these tests run offline.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.ingestion import DocumentParser
+
+# ---------------------------------------------------------------------------
+# UTF-8 BOM handling
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_with_utf8_bom_does_not_crash(tmp_path):
+    """Windows-saved markdown carries a BOM. Parser must at least not crash.
+
+    Caveat: the BOM currently leaks into the first chunk content; that is
+    suboptimal but not a regression of any prior release. The strict
+    assertion lives below as xfail to track the followup.
+    """
+    bom = b"\xef\xbb\xbf"
+    path = tmp_path / "with_bom.md"
+    path.write_bytes(bom + b"# Title\n\n## Section\n\nContent body.\n")
+
+    parser = DocumentParser()
+    doc = parser.parse_file(path)
+    assert doc is not None
+    assert doc.chunks, "parser produced no chunks for BOM-prefixed markdown"
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Parser does not strip leading UTF-8 BOM from chunk content. "
+        "Tracked as a followup quality improvement; not a regression of any prior release."
+    ),
+    strict=False,
+)
+def test_markdown_strips_utf8_bom_from_chunk(tmp_path):
+    """When the followup fix lands: the BOM must NOT appear inside chunk text."""
+    bom = b"\xef\xbb\xbf"
+    path = tmp_path / "with_bom.md"
+    path.write_bytes(bom + b"# Title\n\n## Section\n\nContent body.\n")
+
+    parser = DocumentParser()
+    doc = parser.parse_file(path)
+    assert doc is not None
+    first_chunk_text = doc.chunks[0].content
+    assert "﻿" not in first_chunk_text
+
+
+def test_csv_with_utf8_bom_parses(tmp_path):
+    """Excel-exported CSVs always include a BOM. Parser must accept."""
+    bom = "﻿"
+    path = tmp_path / "with_bom.csv"
+    path.write_text(bom + "Name,Role\nAlice,Admin\nBob,User\n", encoding="utf-8")
+
+    parser = DocumentParser()
+    doc = parser.parse_file(path)
+    assert doc is not None
+    assert doc.chunks
+
+
+# ---------------------------------------------------------------------------
+# Non-ASCII filenames and paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "documento_em_portugues.md",
+        "rapport_français.md",
+        "Bericht_größe.md",
+        "файл.md",  # Cyrillic
+        "file with spaces.md",
+        "file-with-emoji-🚀.md",
+    ],
+)
+def test_non_ascii_filename_parses(tmp_path, filename):
+    """Filenames with accents, spaces, and unicode must not break the parser."""
+    path = tmp_path / filename
+    try:
+        path.write_text("# Heading\n\nBody.\n", encoding="utf-8")
+    except OSError as exc:
+        pytest.skip(f"Filesystem rejects this filename ({exc}) — host-specific limitation, not a parser bug")
+
+    parser = DocumentParser()
+    doc = parser.parse_file(path)
+    assert doc is not None
+    assert doc.chunks
+
+
+def test_path_with_accented_subdirectory(tmp_path):
+    """Subdirectory names with accents must not affect chunk extraction."""
+    subdir = tmp_path / "categoría_segurança"
+    subdir.mkdir()
+    path = subdir / "test.md"
+    path.write_text("# Title\n\nContent.\n", encoding="utf-8")
+
+    parser = DocumentParser()
+    doc = parser.parse_file(path)
+    assert doc is not None
+    assert doc.chunks
+
+
+# ---------------------------------------------------------------------------
+# Mixed-script content
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_with_mixed_scripts(tmp_path):
+    """Real-world docs frequently mix English with other scripts."""
+    content = """# Multi-script document
+
+## Portuguese
+Atenção: este é um teste com acentos e cedilha (ção, ã, ñ).
+
+## Russian (Cyrillic)
+Это тестовый документ.
+
+## Greek
+Αυτό είναι ένα δοκιμαστικό έγγραφο.
+
+## CJK
+これは日本語のテストドキュメントです。
+这是中文测试文档。
+
+## Mixed inline
+The token "São Paulo" should survive chunk boundaries cleanly.
+"""
+    path = tmp_path / "mixed.md"
+    path.write_text(content, encoding="utf-8")
+
+    parser = DocumentParser()
+    doc = parser.parse_file(path)
+    assert doc is not None
+    assert doc.chunks
+    # Reassemble all chunks and verify no character was silently mangled
+    full = "".join(c.content for c in doc.chunks)
+    assert "São Paulo" in full
+    assert "Это" in full
+    assert "Αυτό" in full
+    assert "日本語" in full
+
+
+# ---------------------------------------------------------------------------
+# Line ending tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_crlf_and_lf_produce_same_chunks(tmp_path):
+    """Windows (CRLF) and Unix (LF) line endings must yield equivalent chunks."""
+    body = "# Title\n\n## Section A\n\nFirst paragraph.\n\n## Section B\n\nSecond paragraph.\n"
+
+    lf_path = tmp_path / "lf.md"
+    lf_path.write_bytes(body.encode("utf-8"))
+
+    crlf_path = tmp_path / "crlf.md"
+    crlf_path.write_bytes(body.replace("\n", "\r\n").encode("utf-8"))
+
+    parser = DocumentParser()
+    lf_doc = parser.parse_file(lf_path)
+    crlf_doc = parser.parse_file(crlf_path)
+
+    assert lf_doc is not None and crlf_doc is not None
+    assert len(lf_doc.chunks) == len(crlf_doc.chunks), (
+        "CRLF and LF inputs produced different chunk counts — "
+        "Windows users would see different indexing results from Linux users"
+    )

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,89 @@
+"""Validate every preset YAML in presets/ loads cleanly.
+
+Pillar 4: Versatility — guarantee the 4 shipped configuration profiles
+(``cybersecurity``, ``developer``, ``research``, ``general``) remain valid
+and structurally complete after every PR. A regression here breaks
+freshly installed users who pick a preset out of the box.
+
+We validate the YAML structurally rather than instantiating ``Config``
+directly because Config has runtime side effects (path resolution,
+data_dir creation) that depend on the host filesystem.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+PRESETS_DIR = Path(__file__).parent.parent / "presets"
+
+# Required top-level sections every preset must declare for compatibility
+REQUIRED_TOP_LEVEL = {"models", "documents"}
+
+# Embedding model promise — all presets must use the same dim so the
+# index format is portable across presets without rebuild.
+EXPECTED_EMBEDDING_DIM = 384
+
+
+@pytest.fixture(params=sorted(PRESETS_DIR.glob("*.yaml")), ids=lambda p: p.stem)
+def preset_yaml(request):
+    """Yield each preset YAML path so each preset gets its own test run."""
+    return request.param
+
+
+def test_preset_yaml_parses(preset_yaml):
+    """The YAML must parse without raising and produce a top-level mapping."""
+    data = yaml.safe_load(preset_yaml.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{preset_yaml.name}: top-level must be a mapping"
+
+
+def test_preset_has_required_top_level_sections(preset_yaml):
+    """Every preset must declare the contract sections."""
+    data = yaml.safe_load(preset_yaml.read_text(encoding="utf-8"))
+    missing = REQUIRED_TOP_LEVEL - data.keys()
+    assert not missing, f"{preset_yaml.name}: missing required sections {missing}"
+
+
+def test_preset_embedding_section_intact(preset_yaml):
+    """``models.embedding`` must declare a model name and a 384D dimension."""
+    data = yaml.safe_load(preset_yaml.read_text(encoding="utf-8"))
+    embedding = data.get("models", {}).get("embedding", {})
+    assert isinstance(embedding, dict), f"{preset_yaml.name}: models.embedding must be a mapping"
+    assert "model" in embedding, f"{preset_yaml.name}: models.embedding.model is required"
+    assert embedding.get("dimensions", EXPECTED_EMBEDDING_DIM) == EXPECTED_EMBEDDING_DIM, (
+        f"{preset_yaml.name}: dimensions must remain {EXPECTED_EMBEDDING_DIM} so indices stay portable"
+    )
+
+
+def test_preset_reranker_declared_when_section_present(preset_yaml):
+    """If a preset opts to declare reranker config, it must include a model name."""
+    data = yaml.safe_load(preset_yaml.read_text(encoding="utf-8"))
+    reranker = data.get("models", {}).get("reranker")
+    if reranker is None:
+        pytest.skip(f"{preset_yaml.name} does not declare a reranker section")
+    assert isinstance(reranker, dict), f"{preset_yaml.name}: models.reranker must be a mapping"
+    assert "model" in reranker, f"{preset_yaml.name}: models.reranker.model is required when section is declared"
+
+
+def test_preset_chunking_within_sane_bounds(preset_yaml):
+    """If chunking is declared, sizes must fit production-realistic ranges."""
+    data = yaml.safe_load(preset_yaml.read_text(encoding="utf-8"))
+    chunking = data.get("documents", {}).get("chunking")
+    if chunking is None:
+        pytest.skip(f"{preset_yaml.name} relies on default chunking")
+    chunk_size = chunking.get("chunk_size", 1000)
+    chunk_overlap = chunking.get("chunk_overlap", 200)
+    assert 200 <= chunk_size <= 4000, f"{preset_yaml.name}: chunk_size {chunk_size} outside sane range"
+    assert 0 <= chunk_overlap < chunk_size, (
+        f"{preset_yaml.name}: chunk_overlap {chunk_overlap} must be < chunk_size {chunk_size}"
+    )
+
+
+def test_at_least_four_presets_shipped():
+    """Releasing the project without all four named presets is a regression."""
+    expected = {"cybersecurity", "developer", "research", "general"}
+    actual = {p.stem for p in PRESETS_DIR.glob("*.yaml")}
+    missing = expected - actual
+    assert not missing, f"Missing presets: {missing}"


### PR DESCRIPTION
## Summary

**Onda 3 of 5** toward v3.9.0 Quality Gate. Adds Pillars 4 (Versatility) and 7 (Quality) — 8 new CI jobs + matrix expansion to 9 cells.

## Pillar 4 — Versatility (3 blocking gates)

| Gate | What it asserts |
|---|---|
| Preset matrix | Every shipped preset YAML (cybersecurity / developer / research / general) parses and declares contract sections. 21 tests parametrized. |
| Locale matrix | Parser tolerates UTF-8 BOM, accented filenames, mixed-script content (pt/ru/el/CJK), CRLF vs LF. 11 tests + 1 xfail tracking BOM-strip followup. |
| Format smoke matrix | 14 supported text formats (md/txt/py/json/csv/c/h/cpp/js/jsx/ts/tsx/xml/ipynb) produce non-empty chunks on small fixtures. 29 tests. |

### CI matrix expanded from 4 → 9 cells

```
Stable (blocking):  ubuntu-latest, windows-latest x  3.11, 3.12     -> 4 cells
Experimental:       macos-latest                  x  3.11, 3.12     -> 2 cells
                    {ubuntu, windows, macos}      x  3.13           -> 3 cells
```

Experimental cells use `continue-on-error: true` during stabilization (fastembed/onnxruntime wheels for those targets are still catching up). Promotion to required happens once two consecutive nightlies are green.

## Pillar 7 — Quality (5 gates: 2 blocking, 3 report-only)

| Gate | Mode | Behavior |
|---|---|---|
| `mypy --strict` | **Blocking** | Runs on the allowlist of fully-annotated modules (`instance_lock.py`, `preflight.py`, `scripts/`). Legacy modules join as they earn annotations — gradual rollout. |
| `interrogate >=80%` | **Blocking** | Docstring coverage check. Currently 95.7%, threshold 80%. |
| `radon cc` | Report-only | Cyclomatic complexity. Reports C+ blocks to step summary. Config/orchestrator.query are known D/E — refactor follows in Onda 4 cleanup wave. |
| `vulture` | Report-only | Dead-code scan, min-confidence 80. Whitelist covers signal-handler false positive. |
| PR size guard | Warn-only | Counts code-only diff (excludes md/lockfiles). >500 lines emits visible warning. Does NOT block. |

## Annotation cleanup

To get `mypy --strict` clean on the allowlist:
- `mcp_server/instance_lock.py` — typed signal handler frame param
- `scripts/check_version_sync.py` — explicit isinstance check on json value
- `scripts/check_api_surface.py` — parametrized `dict[str, Any]` generics

## Tooling

- `pyproject.toml` — new `[tool.mypy]` strict + `[tool.interrogate]` config
- `.vulture_whitelist.py` — false-positive suppressions

## Files

```
.github/workflows/ci.yml                      matrix 4 -> 9 cells
.github/workflows/quality-gate.yml            +8 jobs (3 versatility + 5 quality)
.vulture_whitelist.py                         new
mcp_server/instance_lock.py                   1-line annotation fix
pyproject.toml                                +mypy + interrogate config
scripts/check_api_surface.py                  generic type annotations
scripts/check_version_sync.py                 explicit isinstance guard
tests/test_presets.py                         new — 21 parametrized
tests/test_locale.py                          new — 12 cases (11 + 1 xfail)
tests/test_format_smoke.py                    new — 29 parametrized
tests/fixtures/formats/sample.{md,txt,py,...} 14 fixtures
```

## Local validation

```
$ pytest tests/test_presets.py tests/test_locale.py tests/test_format_smoke.py
  61 passed, 1 xfailed in 0.73s

$ mypy mcp_server/instance_lock.py mcp_server/preflight.py scripts/
  Success: no issues found in 5 source files

$ interrogate -c pyproject.toml mcp_server/
  TOTAL 70 3 67 95.7%   PASSED (minimum: 80.0%, actual: 95.7%)

$ ruff check mcp_server/ tests/ scripts/
  All checks passed!
```

## What is NOT in this PR

- No runtime code change (all changes are tooling, tests, fixtures, annotations)
- No Pillar 2/3/5 — those land in Onda 4
- No version bump — still 3.8.1
- No branch protection rule changes — observe a few green PRs first

## Reviewer notes

- This PR will be validated by every existing pillar from Onda 1+2 PLUS the 8 new ones it introduces.
- Expect ~12-13 status checks. Stable cells must pass; experimental (macOS, 3.13) may report failure but do NOT block.
- `radon`, `vulture`, `pr-size` jobs are **report-only by design** — they show summaries but cannot fail the gate. This keeps reviewer signal noise low while still surfacing complexity hotspots.

## Onda 3 of 5

**Next: Onda 4** — Stability + Memory + Scalability (`pytest-rerunfailures`, coverage trend gate, `pytest-memray` baseline, `bench/` suite with perf gate at 10% regression, GH Pages dashboard, nightly workflow with mutation testing + soak + chaos).