### PR TITLE
fix(docker): remove deleted documents/examples copy, add presets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /app
 
 COPY pyproject.toml requirements.txt ./
 COPY mcp_server/ ./mcp_server/
-COPY documents/examples/ ./documents/examples/
-COPY LICENSE README.md ./
+COPY presets/ ./presets/
+COPY config.example.yaml LICENSE README.md ./
 
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
Cleanup PR removed documents/examples/ — Dockerfile still referenced it. Replaces with presets/ + config.example.yaml so Docker users get the same defaults as PyPI/NPM users.