### PR TITLE
chore(docker): bump Python base to 3.13-slim + pin >=3.14 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,3 +61,8 @@ updates:
       - "docker"
       - "dependencies"
     open-pull-requests-limit: 2
+    ignore:
+      # Pin Docker base Python to versions covered by CI matrix.
+      # Promote 3.14+ here AFTER it lands green in ci.yml + quality-gate.yml.
+      - dependency-name: "python"
+        versions: [">=3.14"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 LABEL maintainer="Lyon. <lyonzin@users.noreply.github.com>"
 LABEL description="Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 12 MCP Tools + 20 Format Parsers"


### PR DESCRIPTION
## Summary

- Bumps Docker base from `python:3.12-slim` → `python:3.13-slim`. 3.13 is **tier-1 required** in `ci.yml` + `quality-gate.yml` matrices since v3.9.0 — fully exercised, zero risk.
- Pins `python>=3.14` in `.github/dependabot.yml` Docker section: dependabot wont reopen 3.14 PRs until 3.14 enters the CI matrix and lands green.

## Why not 3.14 (PR #27)?

PyPI wheels exist for 3.14 across all heavy deps (onnxruntime 1.26 cp314 manylinux, chromadb 1.5 abi3, pymupdf cp314, fastembed pure-py). So 3.14 *should* work.

But our matrix tops out at 3.13 — meaning **the suite has never run on 3.14**. With 70+ enterprise users on `:latest`, "should work" is not the bar. Promote to 3.14 only after:

1. Add 3.14 to `ci.yml` matrix
2. Add 3.14 to `quality-gate.yml` jobs
3. 2 nightly runs green
4. *Then* lift the dependabot pin and merge a fresh bump

## Test plan

- [ ] Quality Gate green (35+ checks)
- [ ] 9-cell CI matrix green
- [ ] Docker build succeeds in `release.yml` dry path

Closes #27.