### PR TITLE
chore(glama): restore glama.json to repo root + update metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,12 @@ documents/README-CATEGORIES.md
 *.tar.gz
 *.bak
 
+# Type-checker cache (per-Python-version, auto-generated)
+.mypy_cache/
+
+# Hypothesis property-based testing cache (auto-generated)
+.hypothesis/
+
 # OS files
 .DS_Store
 Thumbs.db

--- a/glama.json
+++ b/glama.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
   "name": "knowledge-rag",
   "display_name": "Knowledge RAG",
   "description": "Local RAG system for Claude Code with hybrid search (semantic + BM25), cross-encoder reranking, markdown-aware chunking, query expansion, file watcher, and 12 MCP tools. Zero external servers.",
@@ -7,6 +8,7 @@
   "homepage": "https://pypi.org/project/knowledge-rag/",
   "license": "MIT",
   "runtime": "python",
+  "maintainers": ["lyonzin"],
   "tags": ["rag", "search", "knowledge-base", "embeddings", "reranking", "claude-code", "local-ai", "mcp"],
   "categories": ["Knowledge & Memory", "Search", "Developer Tools"],
   "features": [
@@ -16,7 +18,9 @@
     "Query expansion (54 security/technical term synonyms)",
     "File watcher (auto-reindex on document changes)",
     "MMR result diversification",
-    "9 file formats (MD, PDF, DOCX, XLSX, PPTX, CSV, TXT, PY, JSON)",
+    "Lazy-load ONNX embeddings (zero cold-start cost)",
+    "Query cache LRU+TTL (instant repeat queries)",
+    "10 file formats (MD, PDF, DOCX, XLSX, PPTX, CSV, TXT, PY, JSON, IPYNB)",
     "12 MCP tools (search, CRUD, URL ingestion, similarity, evaluation)",
     "Incremental indexing with content-hash deduplication",
     "Zero external servers (ONNX in-process via FastEmbed)"


### PR DESCRIPTION
## Summary

- **Root cause**: commit #47 (`chore(repo): clean root layout`) moved `glama.json` from `./` to `.github/`. Glama only scans the repository root — the file became invisible, profile metadata was lost, and the server rating dropped to C.
- Move `.github/glama.json` → `glama.json` (root)
- Add `$schema` and `maintainers` fields required by Glama schema
- Update features list: add lazy-load ONNX embeddings, query cache LRU+TTL
- Fix format count: 9 → 10 (IPYNB support was added in v3.7, never reflected here)
- Add `.hypothesis/` and `.mypy_cache/` to `.gitignore` (hygiene gap from audit)

## Expected impact

After Glama rescans (automatic daily, or manual via admin "Sync Server"):
- "No glama.json" → resolved
- Server metadata (description, features, categories, tags) restored in Glama directory
- Profile completion score recovers

## Checklist

- [x] `glama.json` at repo root
- [x] `$schema: https://glama.ai/mcp/schemas/server.json`
- [x] `maintainers: ["lyonzin"]`
- [x] `.github/glama.json` removed (no duplicate)
- [x] No changelog entry needed (`skip-changelog` — config-only change)