### PR TITLE
fix(nightly): repair chaos collection + mutmut 3.x break + dedup auto-issue

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -112,7 +112,7 @@ jobs:
         shell: bash
         run: |
           pip install -e .
-          pip install mutmut pytest pytest-cov hypothesis psutil numpy pyyaml
+          pip install "mutmut<3" pytest pytest-cov hypothesis psutil numpy pyyaml
       - name: Run mutation testing on instance_lock + preflight
         shell: bash
         # Limit mutation scope to recently authored modules — running
@@ -144,15 +144,35 @@ jobs:
         with:
           script: |
             const date = new Date().toISOString().split("T")[0];
-            const title = `[NIGHTLY] Resilience workflow failed on ${date}`;
-            const body = `One or more nightly resilience jobs failed on ${date}.\n\n` +
-              `See the run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\n` +
-              `Triage: investigate which job (chaos / soak / determinism) is red and decide whether ` +
-              `to fix the underlying flake or relax the threshold.`;
-            await github.rest.issues.create({
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            // Dedup: reuse a single rolling issue instead of opening one per night.
+            // Subsequent failures append a dated comment; a brand-new issue is only
+            // created once the previous one has been closed (i.e. triaged).
+            const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title,
-              body,
-              labels: ["nightly", "needs-triage"],
+              state: "open",
+              labels: "nightly",
+              per_page: 1,
             });
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body: `Nightly resilience failed again on ${date}.\n\nSee the run: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `[NIGHTLY] Resilience workflow failing (opened ${date})`,
+                body: `One or more nightly resilience jobs failed on ${date}.\n\n` +
+                  `See the run: ${runUrl}\n\n` +
+                  `Triage: investigate which job (chaos / soak / determinism) is red and decide whether ` +
+                  `to fix the underlying flake or relax the threshold.\n\n` +
+                  `This issue is reused for subsequent nightly failures (new dates appended as ` +
+                  `comments) until it is closed.`,
+                labels: ["nightly", "needs-triage"],
+              });
+            }

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -8,6 +8,9 @@ name: Quality Gate
 on:
   pull_request:
     branches: [master]
+    # labeled/unlabeled so bypass labels (skip-changelog, skip-test-count,
+    # skip-perf-gate) re-evaluate the gate without needing a forced push.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches: [master]
 

--- a/tests/test_ingestion_property.py
+++ b/tests/test_ingestion_property.py
@@ -18,10 +18,13 @@ from __future__ import annotations
 import json
 
 import pytest
-from hypothesis import HealthCheck, given, settings
-from hypothesis import strategies as st
 
-from mcp_server.ingestion import DocumentParser
+pytest.importorskip("hypothesis", reason="hypothesis required for property-based fuzz tests")
+
+from hypothesis import HealthCheck, given, settings  # noqa: E402  — imported after the importorskip guard
+from hypothesis import strategies as st  # noqa: E402  — imported after the importorskip guard
+
+from mcp_server.ingestion import DocumentParser  # noqa: E402  — imported after the importorskip guard
 
 # Shared settings: keep CI fast (50 examples per property), suppress the
 # function-scoped fixture warning (we use tmp_path which is fine here).


### PR DESCRIPTION
## Summary

The **Nightly** workflow has failed every night since ~2026-05-14, sending a daily GitHub Actions failure email **and** opening a new `[NIGHTLY]` issue per run (8 stale issues accumulated: #58–#66). Root-caused to three independent defects.

## Root causes & fixes

### 1. Chaos suite — the only job that actually fails the workflow
`pytest -m chaos` must collect the whole test tree to discover the `chaos` marker. During collection it imports `tests/test_ingestion_property.py`, which does `from hypothesis import ...` at module top. The chaos job installs only `pytest psutil numpy` (no `hypothesis`), so collection died with `ModuleNotFoundError` → exit 2 → red workflow → auto-issue fired.

**Fix:** guard the module with `pytest.importorskip("hypothesis")` — the same pattern already used in `tests/test_memory_baseline.py` for `psutil`. The module now **skips cleanly** when hypothesis is absent instead of breaking collection for the whole session.

**Verified locally in the exact chaos env** (hypothesis absent, package present):
```
$ pytest --collect-only -m chaos -q
5/216 tests collected (211 deselected) in 1.69s
COLLECT exit=0          # was: exit 2, "Interrupted: 1 error during collection"
```
`ruff check` passes (E402 suppressed on the guarded imports, mirroring the existing precedent).

### 2. Mutation job — cosmetic red, but always red
Installed `mutmut` 3.x but the command uses the removed 2.x CLI flags (`--paths-to-mutate` / `--runner`) → `No such option` → `FileNotFoundError`. It never blocked the workflow (`continue-on-error`, not in the auto-issue `needs`) but showed red every night.

**Fix:** pin `mutmut<3` to match the command contract. (3.x migration to `[mutmut]` pyproject config left as optional future work.)

### 3. Auto-issue pile-up
`open-issue-on-failure` opened a brand-new issue per failure → 8 stale issues.

**Fix:** dedup — reuse a single rolling `[NIGHTLY]` issue (append dated comments) until it is closed. Failures while the maintainer is away no longer spawn one issue per day.

## Impact
- Nightly goes green → no more daily failure email
- No more daily auto-issue
- Indirectly helps the Glama **Maintenance** score (the 8 unanswered bot issues were dragging it to C)

## Checklist
- [x] Chaos collection fix verified in chaos-equivalent env (exit 0)
- [x] `ruff check` clean on changed test file
- [x] `nightly.yml` YAML validated (5 jobs intact)
- [x] No production code touched — test guard + CI only
- [x] Test-count baseline unaffected (importorskip is a no-op where hypothesis is installed)