### PR TITLE
chore(docker): bump base image to python:3.13-slim

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,3 +61,8 @@ updates:
       - "docker"
       - "dependencies"
     open-pull-requests-limit: 2
+    ignore:
+      # Pin Docker base Python to versions covered by CI matrix.
+      # Promote 3.14+ here AFTER it lands green in ci.yml + quality-gate.yml.
+      - dependency-name: "python"
+        versions: [">=3.14"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 LABEL maintainer="Lyon. <lyonzin@users.noreply.github.com>"
 LABEL description="Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 12 MCP Tools + 20 Format Parsers"


### PR DESCRIPTION
## Summary

Revives the change from #49 (closed without merge or explanation). The published Docker `:latest` image still ships **Python 3.12** while CI has tested **3.13 as tier-1 required** since v3.9.0 — so the base image is needlessly behind what's already proven green.

- `Dockerfile`: `python:3.12-slim` → `python:3.13-slim`
- `.github/dependabot.yml`: pin Docker `python` to `<3.14` (ignore `>=3.14`) so dependabot won't jump the base ahead of the CI matrix

## Why 3.13 and not 3.14?

3.13 is fully exercised across the 9-cell CI matrix (Linux/Windows/macOS × 3.11/3.12/3.13) — zero risk. 3.14 isn't in the matrix yet, so the suite has never run on it. With 70+ users on `:latest`, "should work" isn't the bar. Promote to 3.14 only after it lands in `ci.yml` + `quality-gate.yml` green, then lift the dependabot pin.

## Provenance

Cherry-picked the original commit (`44b666a`) onto fresh master — applied cleanly, no conflicts. The stale `chore/dockerfile-python-3.13` branch will be deleted.

## Checklist
- [x] Docker base bumped to a CI-proven Python version
- [x] dependabot pinned to prevent premature 3.14 jump
- [x] No application code changed