### PR TITLE
docs(readme): add star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1342,6 +1342,22 @@ Security Researcher | Developer
 
 ---
 
+## Star History
+
+<div align="center">
+
+<a href="https://www.star-history.com/?repos=lyonzin%2Fknowledge-rag&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=lyonzin/knowledge-rag&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=lyonzin/knowledge-rag&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=lyonzin/knowledge-rag&type=date&legend=top-left" />
+ </picture>
+</a>
+
+</div>
+
+---
+
 <div align="center">
 
 **[Back to Top](#knowledge-rag)**


### PR DESCRIPTION
## What

Adds a **Star History** section to the README footer (after _Author_, before the _Back to Top_ link), using the official star-history.com `<picture>` embed with dark/light theme support.

## Why

Project momentum / social proof visible directly in the README — standard for OSS repos.

## Details

- `## Star History` section, centered via `<div align="center">` to match the existing README style (hero + footer).
- Dark + light variants through `<source media="(prefers-color-scheme: ...)">`.
- Both chart API URLs verified live before commit: `HTTP 200`, `image/svg+xml`, ~64KB each (light + dark).
- Intentionally **not** added to the top nav row — footer/social-proof, consistent with Contributing / License / Author which are also out of nav.

## Scope

Docs-only. No `mcp_server/` change, no public API surface change, no runtime behavior change → `skip-changelog`.

## 7-Pillar

Security / Stability / Memory / Versatility / Scalability / Versioning / Quality — N/A, README markdown only.