### PR TITLE
docs(readme): move star history chart to top

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ pip install knowledge-rag → restart Claude Code → search_knowledge("your que
 
 ---
 
+## Star History
+
+<div align="center">
+
+<a href="https://www.star-history.com/?repos=lyonzin%2Fknowledge-rag&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=lyonzin/knowledge-rag&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=lyonzin/knowledge-rag&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=lyonzin/knowledge-rag&type=date&legend=top-left" />
+ </picture>
+</a>
+
+</div>
+
+---
+
 ## What's New in v3.9.0
 
 ### Quality Gate — 7-Pillar PR Validation
@@ -1339,22 +1355,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 **Lyon.**
 
 Security Researcher | Developer
-
----
-
-## Star History
-
-<div align="center">
-
-<a href="https://www.star-history.com/?repos=lyonzin%2Fknowledge-rag&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=lyonzin/knowledge-rag&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=lyonzin/knowledge-rag&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=lyonzin/knowledge-rag&type=date&legend=top-left" />
- </picture>
-</a>
-
-</div>
 
 ---
 


### PR DESCRIPTION
## What

Moves the **Star History** section from the README footer to just after the hero block (above-the-fold, before _What's New_), for more visibility.

## Why

Maintainer request — give the star-history chart more prominence near the top. Repo has 85★ / 14 forks with an ascending curve, so it works as legitimate social proof up top.

## Details

- Same `<picture>` embed (dark/light), unchanged content — pure relocation (+16/-16, net zero).
- Verified single `## Star History` occurrence (no duplicate).

## Scope

Docs-only. No `mcp_server/` change, no public API surface change → `skip-changelog`.