### PR TITLE
fix(server): orphan cleanup race + cross-doc dedup coupling (#90, #91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1357,6 +1357,8 @@ Common issues:
 - **FIX**: Reranker load failures now fall back to RRF ordering instead of failing `search_knowledge` on offline machines.
 - **FIX**: Virtualenv project-root detection now handles Python symlinks that resolve to the system interpreter.
 - **NEW**: `knowledge-rag-guarded` console script kept as an explicit guarded startup alias.
+- **FIX**: Orphan cleanup now runs before indexing loop, preventing chunk loss when files are moved (#90).
+- **FIX**: Chunk deduplication is now per-document instead of global, preventing cross-document chunk deletion (#91).
 
 ### v3.6.2 (2026-04-23)
 

--- a/README.md
+++ b/README.md
@@ -789,7 +789,6 @@ Get statistics about the knowledge base index.
   "stats": {
     "total_documents": 75,
     "total_chunks": 9256,
-    "unique_content_hashes": 9100,
     "categories": {"security": 52, "development": 8},
     "supported_formats": [".md", ".txt", ".pdf", ".py", ".json", ".docx", ".xlsx", ".pptx", ".csv", ".ipynb"],
     "embedding_model": "BAAI/bge-small-en-v1.5",

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -835,6 +835,14 @@ class DocumentWatcher(FileSystemEventHandler):
         if not event.is_directory and Path(event.src_path).suffix in config.supported_formats:
             self._schedule_reindex(event.src_path)
 
+    def on_moved(self, event):
+        if event.is_directory:
+            return
+        src_supported = Path(event.src_path).suffix in config.supported_formats
+        dest_supported = Path(event.dest_path).suffix in config.supported_formats
+        if src_supported or dest_supported:
+            self._schedule_reindex(event.dest_path)
+
 
 # =============================================================================
 # KNOWLEDGE ORCHESTRATOR
@@ -869,9 +877,6 @@ class KnowledgeOrchestrator:
         # Index metadata cache
         self._metadata_file = config.data_dir / "index_metadata.json"
         self._indexed_docs: Dict[str, Dict] = self._load_metadata()
-
-        # Chunk dedup tracking (content_hash -> chunk_id)
-        self._chunk_hashes: Dict[str, str] = self._build_dedup_index()
 
         # Migration: deferred — checked in main() after full init
         self._needs_rebuild = False
@@ -1031,11 +1036,24 @@ class KnowledgeOrchestrator:
         for doc_id, info in self._indexed_docs.items():
             path_to_docid[info.get("source", "")] = doc_id
 
-        current_paths = set()
+        current_paths = {str(doc.source) for doc in documents}
+
+        # Clean up orphaned docs BEFORE indexing so that moved files
+        # are not blocked by stale content hashes (fixes #90).
+        orphan_ids = []
+        for doc_id, info in list(self._indexed_docs.items()):
+            if info.get("source", "") not in current_paths:
+                removed = self._remove_document_chunks(doc_id)
+                stats["chunks_removed"] += removed
+                stats["deleted"] += 1
+                orphan_ids.append(doc_id)
+
+        for doc_id in orphan_ids:
+            del self._indexed_docs[doc_id]
+
         _progress_interval = max(1, stats["total_files"] // 10)
 
         for idx, doc in enumerate(documents):
-            current_paths.add(str(doc.source))
             try:
                 source_str = str(doc.source)
                 existing_doc_id = path_to_docid.get(source_str)
@@ -1103,18 +1121,6 @@ class KnowledgeOrchestrator:
                     f"— {stats['indexed']} new, {stats['skipped']} skipped"
                 )
 
-        # Clean up orphaned docs
-        orphan_ids = []
-        for doc_id, info in list(self._indexed_docs.items()):
-            if info.get("source", "") not in current_paths:
-                removed = self._remove_document_chunks(doc_id)
-                stats["chunks_removed"] += removed
-                stats["deleted"] += 1
-                orphan_ids.append(doc_id)
-
-        for doc_id in orphan_ids:
-            del self._indexed_docs[doc_id]
-
         self._save_metadata()
 
         if stats["indexed"] > 0 or stats["updated"] > 0 or stats["deleted"] > 0:
@@ -1137,16 +1143,17 @@ class KnowledgeOrchestrator:
         unique_docs = []
         unique_metas = []
         dedup_skipped = 0
+        seen_hashes: set = set()
 
         for chunk in doc.chunks:
             content_hash = hashlib.sha256(chunk.content.encode("utf-8")).hexdigest()[:20]
             chunk_id = f"{doc.id}_{chunk.index}"
 
-            if content_hash in self._chunk_hashes:
+            if content_hash in seen_hashes:
                 dedup_skipped += 1
                 continue
 
-            self._chunk_hashes[content_hash] = chunk_id
+            seen_hashes.add(content_hash)
             unique_ids.append(chunk_id)
             unique_docs.append(chunk.content)
             unique_metas.append(
@@ -1178,14 +1185,9 @@ class KnowledgeOrchestrator:
     def _remove_document_chunks(self, doc_id: str) -> int:
         """Remove all chunks belonging to a document from ChromaDB and BM25."""
         try:
-            results = self.collection.get(where={"doc_id": doc_id}, include=["metadatas"])
+            results = self.collection.get(where={"doc_id": doc_id}, include=[])
 
             if results["ids"]:
-                for meta in results["metadatas"]:
-                    content_hash = meta.get("content_hash", "")
-                    if content_hash and content_hash in self._chunk_hashes:
-                        del self._chunk_hashes[content_hash]
-
                 self.collection.delete(ids=results["ids"])
                 self._bm25_initialized = False
                 return len(results["ids"])
@@ -1193,21 +1195,6 @@ class KnowledgeOrchestrator:
             print(f"[WARN] Failed to remove chunks for doc {doc_id}: {e}")
 
         return 0
-
-    def _build_dedup_index(self) -> Dict[str, str]:
-        """Build deduplication index from existing ChromaDB data"""
-        dedup = {}
-        try:
-            count = self.collection.count()
-            if count > 0:
-                all_data = self.collection.get(include=["metadatas"], limit=count)
-                for chunk_id, meta in zip(all_data["ids"], all_data["metadatas"]):
-                    content_hash = meta.get("content_hash", "")
-                    if content_hash:
-                        dedup[content_hash] = chunk_id
-        except Exception as e:
-            print(f"[WARN] Failed to build dedup index: {e}")
-        return dedup
 
     def reindex_all(self) -> Dict[str, Any]:
         """Smart reindex: incremental detection + BM25 rebuild + orphan cleanup."""
@@ -1279,7 +1266,6 @@ class KnowledgeOrchestrator:
         self._indexed_docs = {}
         self.bm25_index.clear()
         self._bm25_initialized = False
-        self._chunk_hashes = {}
         self.query_cache.invalidate()
 
         stats = self.index_all(force=True)
@@ -1961,7 +1947,6 @@ class KnowledgeOrchestrator:
         return {
             "total_documents": len(self._indexed_docs),
             "total_chunks": self.collection.count(),
-            "unique_content_hashes": len(self._chunk_hashes),
             "categories": self.list_categories(),
             "supported_formats": config.supported_formats,
             "embedding_model": config.embedding_model,

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -112,8 +112,7 @@ class TestFileMovePreservesChunks:
         chunks_after = orch.collection.count()
 
         assert chunks_after >= chunks_before, (
-            f"Chunks dropped from {chunks_before} to {chunks_after} after move. "
-            "Orphan cleanup raced dedup (issue #90)."
+            f"Chunks dropped from {chunks_before} to {chunks_after} after move. Orphan cleanup raced dedup (issue #90)."
         )
         assert stats2["deleted"] >= 1
 
@@ -122,18 +121,14 @@ class TestFileMovePreservesChunks:
 
         (docs_dir / "alpha.md").write_text(CONTENT_A, encoding="utf-8")
         orch.index_all(force=True)
-        chunks_before = len(
-            orch.collection.get(where={"filename": "alpha.md"}, include=[])["ids"]
-        )
+        chunks_before = len(orch.collection.get(where={"filename": "alpha.md"}, include=[])["ids"])
 
         sub = docs_dir / "sub"
         sub.mkdir()
         (docs_dir / "alpha.md").rename(sub / "alpha.md")
         orch.index_all(force=False)
 
-        chunks_after = len(
-            orch.collection.get(where={"filename": "alpha.md"}, include=[])["ids"]
-        )
+        chunks_after = len(orch.collection.get(where={"filename": "alpha.md"}, include=[])["ids"])
         assert chunks_after == chunks_before, (
             f"Chunks went from {chunks_before} to {chunks_after} after move+reindex. "
             "File content should still be fully searchable."
@@ -150,17 +145,13 @@ class TestCrossDocDedup:
         (docs_dir / "beta.md").write_text(CONTENT_B, encoding="utf-8")
         orch.index_all(force=True)
 
-        beta_chunks_before = orch.collection.get(
-            where={"filename": "beta.md"}, include=[]
-        )
+        beta_chunks_before = orch.collection.get(where={"filename": "beta.md"}, include=[])
         assert len(beta_chunks_before["ids"]) > 0
 
         (docs_dir / "alpha.md").unlink()
         orch.index_all(force=False)
 
-        beta_chunks_after = orch.collection.get(
-            where={"filename": "beta.md"}, include=[]
-        )
+        beta_chunks_after = orch.collection.get(where={"filename": "beta.md"}, include=[])
         assert len(beta_chunks_after["ids"]) == len(beta_chunks_before["ids"]), (
             f"Beta chunks dropped from {len(beta_chunks_before['ids'])} to "
             f"{len(beta_chunks_after['ids'])} after removing alpha. "
@@ -179,9 +170,7 @@ class TestCrossDocDedup:
 
         assert len(c1["ids"]) > 0, "copy1 has no chunks"
         assert len(c2["ids"]) > 0, "copy2 has no chunks — global dedup suppressed it"
-        assert len(c1["ids"]) == len(c2["ids"]), (
-            "Identical files should have the same number of chunks each."
-        )
+        assert len(c1["ids"]) == len(c2["ids"]), "Identical files should have the same number of chunks each."
 
     def test_remove_one_copy_other_intact(self, rag_env):
         orch, docs_dir = rag_env
@@ -190,16 +179,12 @@ class TestCrossDocDedup:
         (docs_dir / "copy2.md").write_text(CONTENT_A, encoding="utf-8")
         orch.index_all(force=True)
 
-        count_before = len(
-            orch.collection.get(where={"filename": "copy2.md"}, include=[])["ids"]
-        )
+        count_before = len(orch.collection.get(where={"filename": "copy2.md"}, include=[])["ids"])
 
         (docs_dir / "copy1.md").unlink()
         orch.index_all(force=False)
 
-        count_after = len(
-            orch.collection.get(where={"filename": "copy2.md"}, include=[])["ids"]
-        )
+        count_after = len(orch.collection.get(where={"filename": "copy2.md"}, include=[])["ids"])
         assert count_after == count_before, (
             f"copy2 chunks dropped from {count_before} to {count_after} "
             "after removing copy1 — cross-doc dedup coupling."

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,206 @@
+"""Regression tests for chunk dedup integrity (#90, #91).
+
+#90: Moving an indexed file must not lose chunks on reindex.
+#91: Removing a document must not delete chunks shared with another document.
+
+These tests use a real ChromaDB (tmp_path) with mocked embeddings to exercise
+the actual indexing pipeline without requiring model downloads.
+"""
+
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+
+class _FakeEmbeddings:
+    """Minimal embedding function that satisfies ChromaDB's full interface."""
+
+    _dim = 384
+    is_legacy = False
+
+    def __call__(self, input: List[str]) -> List[List[float]]:
+        return [[0.1] * 384 for _ in input]
+
+    @staticmethod
+    def name() -> str:
+        return "fake-test-embeddings"
+
+    @staticmethod
+    def build_from_config(config):  # noqa: ARG004
+        return _FakeEmbeddings()
+
+    @staticmethod
+    def get_config():
+        return {}
+
+    @staticmethod
+    def validate_config_update(old_config, new_config):  # noqa: ARG004
+        pass
+
+
+@pytest.fixture
+def rag_env(tmp_path, monkeypatch):
+    """Isolated RAG environment: real ChromaDB, mocked embeddings, tmp dirs."""
+    docs_dir = tmp_path / "documents"
+    docs_dir.mkdir()
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    chroma_dir = data_dir / "chroma_db"
+    chroma_dir.mkdir()
+    models_dir = tmp_path / "models_cache"
+    models_dir.mkdir()
+
+    import mcp_server.config as cfg
+
+    monkeypatch.setattr(cfg.config, "documents_dir", docs_dir)
+    monkeypatch.setattr(cfg.config, "data_dir", data_dir)
+    monkeypatch.setattr(cfg.config, "chroma_dir", chroma_dir)
+    monkeypatch.setattr(cfg.config, "models_cache_dir", models_dir)
+    monkeypatch.setattr(cfg.config, "transport", "stdio")
+
+    with patch("mcp_server.server.FastEmbedEmbeddings", _FakeEmbeddings):
+        from mcp_server.server import KnowledgeOrchestrator
+
+        orch = KnowledgeOrchestrator()
+        yield orch, docs_dir
+
+
+CONTENT_A = """\
+# Document Alpha
+
+## Overview
+
+This document covers advanced SQL injection bypass techniques including
+UNION-based, blind boolean, and time-based attacks against web applications.
+
+## Methodology
+
+Use parameterized queries and input validation as primary defenses.
+"""
+
+CONTENT_B = """\
+# Document Beta
+
+## Overview
+
+Cross-site scripting attack vectors for reflected, stored, and DOM-based
+XSS in modern single-page applications with CSP bypass techniques.
+
+## Methodology
+
+Use parameterized queries and input validation as primary defenses.
+"""
+
+
+class TestFileMovePreservesChunks:
+    """#90: Moving an indexed file must re-index at the new path."""
+
+    def test_move_file_chunks_preserved(self, rag_env):
+        orch, docs_dir = rag_env
+
+        (docs_dir / "alpha.md").write_text(CONTENT_A, encoding="utf-8")
+        stats1 = orch.index_all(force=True)
+        assert stats1["chunks_added"] > 0
+        chunks_before = orch.collection.count()
+
+        sub = docs_dir / "sub"
+        sub.mkdir()
+        (docs_dir / "alpha.md").rename(sub / "alpha.md")
+
+        stats2 = orch.index_all(force=False)
+        chunks_after = orch.collection.count()
+
+        assert chunks_after >= chunks_before, (
+            f"Chunks dropped from {chunks_before} to {chunks_after} after move. "
+            "Orphan cleanup raced dedup (issue #90)."
+        )
+        assert stats2["deleted"] >= 1
+
+    def test_move_file_searchable_after_reindex(self, rag_env):
+        orch, docs_dir = rag_env
+
+        (docs_dir / "alpha.md").write_text(CONTENT_A, encoding="utf-8")
+        orch.index_all(force=True)
+        chunks_before = len(
+            orch.collection.get(where={"filename": "alpha.md"}, include=[])["ids"]
+        )
+
+        sub = docs_dir / "sub"
+        sub.mkdir()
+        (docs_dir / "alpha.md").rename(sub / "alpha.md")
+        orch.index_all(force=False)
+
+        chunks_after = len(
+            orch.collection.get(where={"filename": "alpha.md"}, include=[])["ids"]
+        )
+        assert chunks_after == chunks_before, (
+            f"Chunks went from {chunks_before} to {chunks_after} after move+reindex. "
+            "File content should still be fully searchable."
+        )
+
+
+class TestCrossDocDedup:
+    """#91: Removing one doc must not delete chunks from another doc."""
+
+    def test_shared_content_survives_removal(self, rag_env):
+        orch, docs_dir = rag_env
+
+        (docs_dir / "alpha.md").write_text(CONTENT_A, encoding="utf-8")
+        (docs_dir / "beta.md").write_text(CONTENT_B, encoding="utf-8")
+        orch.index_all(force=True)
+
+        beta_chunks_before = orch.collection.get(
+            where={"filename": "beta.md"}, include=[]
+        )
+        assert len(beta_chunks_before["ids"]) > 0
+
+        (docs_dir / "alpha.md").unlink()
+        orch.index_all(force=False)
+
+        beta_chunks_after = orch.collection.get(
+            where={"filename": "beta.md"}, include=[]
+        )
+        assert len(beta_chunks_after["ids"]) == len(beta_chunks_before["ids"]), (
+            f"Beta chunks dropped from {len(beta_chunks_before['ids'])} to "
+            f"{len(beta_chunks_after['ids'])} after removing alpha. "
+            "Cross-document dedup coupling (issue #91)."
+        )
+
+    def test_identical_files_both_indexed(self, rag_env):
+        orch, docs_dir = rag_env
+
+        (docs_dir / "copy1.md").write_text(CONTENT_A, encoding="utf-8")
+        (docs_dir / "copy2.md").write_text(CONTENT_A, encoding="utf-8")
+        orch.index_all(force=True)
+
+        c1 = orch.collection.get(where={"filename": "copy1.md"}, include=[])
+        c2 = orch.collection.get(where={"filename": "copy2.md"}, include=[])
+
+        assert len(c1["ids"]) > 0, "copy1 has no chunks"
+        assert len(c2["ids"]) > 0, "copy2 has no chunks — global dedup suppressed it"
+        assert len(c1["ids"]) == len(c2["ids"]), (
+            "Identical files should have the same number of chunks each."
+        )
+
+    def test_remove_one_copy_other_intact(self, rag_env):
+        orch, docs_dir = rag_env
+
+        (docs_dir / "copy1.md").write_text(CONTENT_A, encoding="utf-8")
+        (docs_dir / "copy2.md").write_text(CONTENT_A, encoding="utf-8")
+        orch.index_all(force=True)
+
+        count_before = len(
+            orch.collection.get(where={"filename": "copy2.md"}, include=[])["ids"]
+        )
+
+        (docs_dir / "copy1.md").unlink()
+        orch.index_all(force=False)
+
+        count_after = len(
+            orch.collection.get(where={"filename": "copy2.md"}, include=[])["ids"]
+        )
+        assert count_after == count_before, (
+            f"copy2 chunks dropped from {count_before} to {count_after} "
+            "after removing copy1 — cross-doc dedup coupling."
+        )


### PR DESCRIPTION
## Summary

- **#90 — Orphan cleanup race on file move**: Reordered `_index_all_impl` so orphan cleanup runs BEFORE the indexing loop. Previously, moved files had their old entry cleaned up (including content hashes) after the new entry was indexed, causing the new chunks to be silently dropped by dedup. Also added `on_moved` handler to `DocumentWatcher`.
- **#91 — Cross-document dedup coupling**: Replaced global `_chunk_hashes: Dict[str, str]` with per-document `seen_hashes: set` inside `_index_document`. Removing one document no longer cascades to chunks in other documents that share identical content. Removed `_build_dedup_index()` (O(n) startup scan no longer needed).
- **Docs**: Removed `unique_content_hashes` from `get_index_stats` example in README (field no longer exists).

## Test plan

- [x] 5 regression tests (`tests/test_dedup.py`): move-preserves-chunks, move-searchable-after-reindex, shared-content-survives-removal, identical-files-both-indexed, remove-one-copy-other-intact
- [x] Full suite: **215 passed**, 0 failed
- [x] E2E validation of all 12 MCP tools against live server (real ChromaDB + real embeddings)

Closes #90
Closes #91