### PR TITLE
chore(release): v4.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1353,12 +1353,15 @@ Common issues:
 
 ### Unreleased
 
+### v4.0.1 (2026-06-16)
+
+- **FIX**: Orphan cleanup now runs before indexing loop, preventing chunk loss when files are moved (#90).
+- **FIX**: Chunk deduplication is now per-document instead of global, preventing cross-document chunk deletion (#91).
+- **FIX**: Added `on_moved` handler to `DocumentWatcher` for proper file move detection.
 - **FIX**: Startup preflight probes ChromaDB in a child process and moves crashing persistent indexes to `data/backups/auto-repair-*` before MCP initialization.
 - **FIX**: Reranker load failures now fall back to RRF ordering instead of failing `search_knowledge` on offline machines.
 - **FIX**: Virtualenv project-root detection now handles Python symlinks that resolve to the system interpreter.
 - **NEW**: `knowledge-rag-guarded` console script kept as an explicit guarded startup alias.
-- **FIX**: Orphan cleanup now runs before indexing loop, preventing chunk loss when files are moved (#90).
-- **FIX**: Chunk deduplication is now per-document instead of global, preventing cross-document chunk deletion (#91).
 
 ### v3.6.2 (2026-04-23)
 

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -8,7 +8,7 @@ import sys  # noqa: I001
 _original_stdout = sys.stdout
 sys.stdout = sys.stderr
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 __author__ = "Ailton Rocha (Lyon.)"
 
 from .config import Config  # noqa: E402

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-rag",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 12 MCP Tools + 20 Format Parsers. Zero external servers.",
   "bin": {
     "knowledge-rag": "./bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "knowledge-rag"
-version = "4.0.0"
+version = "4.0.1"
 description = "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 12 MCP Tools + 20 Format Parsers. Zero external servers."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Patch release v4.0.1 — bugfixes only, no breaking changes.

- **#90**: Orphan cleanup reordered before indexing loop + `on_moved` handler added to `DocumentWatcher`
- **#91**: Chunk deduplication changed from global to per-document, eliminating cross-document coupling
- Preflight ChromaDB probe, reranker fallback, virtualenv symlink fix (carried from unreleased)

## Version bumps

- `pyproject.toml`: 4.0.0 → 4.0.1
- `mcp_server/__init__.py`: 4.0.0 → 4.0.1
- `npm/package.json`: 4.0.0 → 4.0.1

## Test plan

- [x] `check_version_sync.py` — all 3 files agree
- [x] CHANGELOG curated under `## v4.0.1 (2026-06-16)`
- [x] 215 tests passing, 5 new regression tests for #90/#91
- [x] `skip-perf-gate` if Pillar 5 jitter recurs (query_cache bench, unrelated to changes)

Closes #90
Closes #91