### PR TITLE
chore(release): v4.1.0

### DIFF
--- a/.github/api-surface-baseline.json
+++ b/.github/api-surface-baseline.json
@@ -137,6 +137,148 @@
         }
       }
     },
+    "mcp_server.metrics": {
+      "classes": {
+        "MetricsCollector": {
+          "bases": [],
+          "methods": {
+            "exposition": {
+              "args": [
+                {
+                  "annotated": false,
+                  "has_default": false,
+                  "kind": "positional",
+                  "name": "self"
+                }
+              ],
+              "is_async": false,
+              "returns_annotated": true
+            },
+            "inc": {
+              "args": [
+                {
+                  "annotated": false,
+                  "has_default": false,
+                  "kind": "positional",
+                  "name": "self"
+                },
+                {
+                  "annotated": true,
+                  "has_default": false,
+                  "kind": "positional",
+                  "name": "name"
+                },
+                {
+                  "annotated": true,
+                  "has_default": true,
+                  "kind": "positional",
+                  "name": "labels"
+                },
+                {
+                  "annotated": true,
+                  "has_default": true,
+                  "kind": "positional",
+                  "name": "value"
+                }
+              ],
+              "is_async": false,
+              "returns_annotated": true
+            },
+            "observe": {
+              "args": [
+                {
+                  "annotated": false,
+                  "has_default": false,
+                  "kind": "positional",
+                  "name": "self"
+                },
+                {
+                  "annotated": true,
+                  "has_default": false,
+                  "kind": "positional",
+                  "name": "name"
+                },
+                {
+                  "annotated": true,
+                  "has_default": false,
+                  "kind": "positional",
+                  "name": "value"
+                },
+                {
+                  "annotated": true,
+                  "has_default": true,
+                  "kind": "positional",
+                  "name": "labels"
+                }
+              ],
+              "is_async": false,
+              "returns_annotated": true
+            },
+            "set_gauge": {
+              "args": [
+                {
+                  "annotated": false,
+                  "has_default": false,
+                  "kind": "positional",
+                  "name": "self"
+                },
+                {
+                  "annotated": true,
+                  "has_default": false,
+                  "kind": "positional",
+                  "name": "name"
+                },
+                {
+                  "annotated": true,
+                  "has_default": false,
+                  "kind": "positional",
+                  "name": "value"
+                },
+                {
+                  "annotated": true,
+                  "has_default": true,
+                  "kind": "positional",
+                  "name": "labels"
+                }
+              ],
+              "is_async": false,
+              "returns_annotated": true
+            }
+          }
+        }
+      },
+      "functions": {
+        "get_metrics": {
+          "args": [],
+          "is_async": false,
+          "returns_annotated": true
+        },
+        "instrument": {
+          "args": [
+            {
+              "annotated": true,
+              "has_default": false,
+              "kind": "positional",
+              "name": "tool_name"
+            }
+          ],
+          "is_async": false,
+          "returns_annotated": true
+        },
+        "start_metrics_server": {
+          "args": [
+            {
+              "annotated": true,
+              "has_default": false,
+              "kind": "positional",
+              "name": "port"
+            }
+          ],
+          "is_async": false,
+          "returns_annotated": true
+        }
+      }
+    },
     "mcp_server.preflight": {
       "classes": {},
       "functions": {
@@ -147,6 +289,47 @@
               "has_default": true,
               "kind": "positional",
               "name": "timeout_seconds"
+            }
+          ],
+          "is_async": false,
+          "returns_annotated": true
+        }
+      }
+    },
+    "mcp_server.ratelimit": {
+      "classes": {
+        "SlidingWindowCounter": {
+          "bases": [],
+          "methods": {
+            "allow": {
+              "args": [
+                {
+                  "annotated": false,
+                  "has_default": false,
+                  "kind": "positional",
+                  "name": "self"
+                },
+                {
+                  "annotated": true,
+                  "has_default": true,
+                  "kind": "positional",
+                  "name": "client_id"
+                }
+              ],
+              "is_async": false,
+              "returns_annotated": true
+            }
+          }
+        }
+      },
+      "functions": {
+        "rate_limited": {
+          "args": [
+            {
+              "annotated": true,
+              "has_default": false,
+              "kind": "positional",
+              "name": "fn"
             }
           ],
           "is_async": false,
@@ -344,6 +527,24 @@
               ],
               "is_async": false,
               "returns_annotated": false
+            },
+            "on_moved": {
+              "args": [
+                {
+                  "annotated": false,
+                  "has_default": false,
+                  "kind": "positional",
+                  "name": "self"
+                },
+                {
+                  "annotated": false,
+                  "has_default": false,
+                  "kind": "positional",
+                  "name": "event"
+                }
+              ],
+              "is_async": false,
+              "returns_annotated": false
             }
           }
         },
@@ -415,8 +616,17 @@
               ],
               "is_async": false,
               "returns_annotated": true
+            },
+            "verify_gpu_readiness": {
+              "args": [],
+              "is_async": false,
+              "returns_annotated": true
             }
           }
+        },
+        "GPUStatus": {
+          "bases": [],
+          "methods": {}
         },
         "KnowledgeOrchestrator": {
           "bases": [],

--- a/README.md
+++ b/README.md
@@ -1369,7 +1369,10 @@ Common issues:
 
 ### Unreleased
 
+### v4.1.0 (2026-06-17)
+
 - **Added:** `query_expansion_groups` config for symmetric synonym expansion (#92)
+- **Improved:** `expand_query()` now returns deterministic expansion order (set → ordered list with dedup)
 
 ### v4.0.1 (2026-06-16)
 

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -8,7 +8,7 @@ import sys  # noqa: I001
 _original_stdout = sys.stdout
 sys.stdout = sys.stderr
 
-__version__ = "4.0.1"
+__version__ = "4.1.0"
 __author__ = "Ailton Rocha (Lyon.)"
 
 from .config import Config  # noqa: E402

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-rag",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 12 MCP Tools + 20 Format Parsers. Zero external servers.",
   "bin": {
     "knowledge-rag": "./bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "knowledge-rag"
-version = "4.0.1"
+version = "4.1.0"
 description = "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 12 MCP Tools + 20 Format Parsers. Zero external servers."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- Version bump 4.0.1 → 4.1.0 (pyproject.toml + __init__.py + package.json)
- CHANGELOG curated: Unreleased → v4.1.0 (2026-06-17)
- API surface baseline regenerated (no breaking changes)

## What's in v4.1.0

- **feat:** `query_expansion_groups` for symmetric synonym expansion (#92, PR #95 by @Hohlas)
- **perf:** `expand_query()` deterministic order (set → ordered list with dedup)

## Labels

- `skip-changelog` — release PR, changelog already curated
- `skip-perf-gate` — no code changes, bump only