### PR TITLE
fix(server): guard _indexed_docs iterations against concurrent watcher mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1369,6 +1369,10 @@ Common issues:
 
 ### Unreleased
 
+### v4.1.1 (2026-06-17)
+
+- **FIX**: All `_indexed_docs` iterations now use `list()` snapshot, preventing `dictionary changed size during iteration` crash when FileWatcher modifies the index concurrently with MCP tool calls (affects `search_knowledge`, `search_similar`, `update_document`, `remove_document`, `evaluate_retrieval`, `list_categories`, `list_documents`)
+
 ### v4.1.0 (2026-06-17)
 
 - **Added:** `query_expansion_groups` config for symmetric synonym expansion (#92)

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -8,7 +8,7 @@ import sys  # noqa: I001
 _original_stdout = sys.stdout
 sys.stdout = sys.stderr
 
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 __author__ = "Ailton Rocha (Lyon.)"
 
 from .config import Config  # noqa: E402

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1050,7 +1050,7 @@ class KnowledgeOrchestrator:
             print(f"[INDEX] Scanning {stats['total_files']} documents...")
 
         path_to_docid: Dict[str, str] = {}
-        for doc_id, info in self._indexed_docs.items():
+        for doc_id, info in list(self._indexed_docs.items()):
             path_to_docid[info.get("source", "")] = doc_id
 
         current_paths = {str(doc.source) for doc in documents}
@@ -1516,7 +1516,7 @@ class KnowledgeOrchestrator:
 
             # Find the doc_id from metadata lookup
             doc_id = None
-            for did, info in self._indexed_docs.items():
+            for did, info in list(self._indexed_docs.items()):
                 stored = str(Path(info.get("source", "")).resolve())
                 if stored == str(Path(source).resolve()):
                     doc_id = did
@@ -1709,7 +1709,7 @@ class KnowledgeOrchestrator:
         filepath_resolved = str(filepath.resolve())
 
         doc_id = None
-        for did, info in self._indexed_docs.items():
+        for did, info in list(self._indexed_docs.items()):
             stored = str(Path(info.get("source", "")).resolve())
             if stored == filepath_resolved:
                 doc_id = did
@@ -1763,7 +1763,7 @@ class KnowledgeOrchestrator:
         filepath_resolved = str(Path(filepath).resolve())
 
         doc_id = None
-        for did, info in self._indexed_docs.items():
+        for did, info in list(self._indexed_docs.items()):
             stored = str(Path(info.get("source", "")).resolve())
             if stored == filepath_resolved:
                 doc_id = did
@@ -1824,7 +1824,7 @@ class KnowledgeOrchestrator:
         filepath_resolved = str(Path(filepath).resolve())
 
         doc_id = None
-        for did, info in self._indexed_docs.items():
+        for did, info in list(self._indexed_docs.items()):
             stored = str(Path(info.get("source", "")).resolve())
             if stored == filepath_resolved:
                 doc_id = did
@@ -1936,7 +1936,7 @@ class KnowledgeOrchestrator:
     def list_categories(self) -> Dict[str, int]:
         """List all categories with document counts"""
         categories = {}
-        for doc_info in self._indexed_docs.values():
+        for doc_info in list(self._indexed_docs.values()):
             cat = doc_info.get("category", "unknown")
             categories[cat] = categories.get(cat, 0) + 1
         return categories
@@ -1944,7 +1944,7 @@ class KnowledgeOrchestrator:
     def list_documents(self, category: Optional[str] = None) -> List[Dict[str, str]]:
         """List all indexed documents, optionally filtered by category"""
         docs = []
-        for doc_id, info in self._indexed_docs.items():
+        for doc_id, info in list(self._indexed_docs.items()):
             if category and info.get("category") != category:
                 continue
             docs.append(

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-rag",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 12 MCP Tools + 20 Format Parsers. Zero external servers.",
   "bin": {
     "knowledge-rag": "./bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "knowledge-rag"
-version = "4.1.0"
+version = "4.1.1"
 description = "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 12 MCP Tools + 20 Format Parsers. Zero external servers."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- Guard all 8 `_indexed_docs` iteration sites with `list()` snapshot to prevent `dictionary changed size during iteration` crash
- Bump v4.1.0 → v4.1.1, CHANGELOG curated, API baseline regenerated

## Root Cause

`FileWatcher` (watchdog) runs in a background thread and modifies `self._indexed_docs` (add/delete entries) when files change on disk. MCP tool handlers iterate the same dict on the main thread without copying — race condition causes `RuntimeError: dictionary changed size during iteration`.

PR #93 (v4.0.1) fixed only 1 of 8 iteration sites (orphan cleanup, line 1061). The remaining 7 were unprotected.

## What changed

All `for ... in self._indexed_docs.items()/values()` → `for ... in list(self._indexed_docs.items()/values())`

Affected functions:
- `index_documents` (path_to_docid build)
- `_expand_context_window`
- `update_document_content`
- `remove_document_by_path`
- `search_similar`
- `list_categories`
- `list_documents`

## Labels

- `skip-perf-gate` — hotfix, `list()` copy overhead negligible on 5K docs