### PR TITLE
fix: accept 'general' as valid category and skip empty BM25-only results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1401,6 +1401,9 @@ Common issues:
 
 ### Unreleased
 
+- **FIX**: Accept `"general"` as a valid category in `search_knowledge` — the parser fallback was missing from `valid_categories`.
+- **FIX**: Skip BM25-only search results when Chroma can no longer resolve the chunk ID (stale after reindex) instead of returning records with empty fields.
+
 ### v4.3.0 (2026-06-17) — Async Reindex, GPU CUDA 12, 13th MCP Tool
 
 - **NEW**: `get_reindex_status` MCP tool — lightweight reindex progress polling without computing full index stats. Returns active/idle status, percent, processed/total, errors, and last result.

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1543,7 +1543,12 @@ class KnowledgeOrchestrator:
             else:
                 try:
                     fetched = self.collection.get(ids=[chunk_id], include=["documents", "metadatas"])
-                    if not fetched["documents"] or not fetched["metadatas"] or not fetched["documents"][0] or not fetched["metadatas"][0]:
+                    if (
+                        not fetched["documents"]
+                        or not fetched["metadatas"]
+                        or not fetched["documents"][0]
+                        or not fetched["metadatas"][0]
+                    ):
                         continue
                     data = {
                         "document": fetched["documents"][0],

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1543,9 +1543,11 @@ class KnowledgeOrchestrator:
             else:
                 try:
                     fetched = self.collection.get(ids=[chunk_id], include=["documents", "metadatas"])
+                    if not fetched["documents"] or not fetched["metadatas"] or not fetched["documents"][0] or not fetched["metadatas"][0]:
+                        continue
                     data = {
-                        "document": fetched["documents"][0] if fetched["documents"] else "",
-                        "metadata": fetched["metadatas"][0] if fetched["metadatas"] else {},
+                        "document": fetched["documents"][0],
+                        "metadata": fetched["metadatas"][0],
                         "distance": 0,
                     }
                 except Exception:
@@ -2273,7 +2275,7 @@ def search_knowledge(
     hybrid_alpha = max(0.0, min(hybrid_alpha if hybrid_alpha is not None else 0.3, 1.0))
     min_score = max(0.0, min(min_score if min_score is not None else 0.0, 1.0))
 
-    valid_categories = list(config.keyword_routes.keys()) + list(set(config.category_mappings.values()))
+    valid_categories = list(config.keyword_routes.keys()) + list(set(config.category_mappings.values())) + ["general"]
     if category and category not in valid_categories:
         return json.dumps(
             {"status": "error", "message": f"Invalid category '{category}'. Valid: {', '.join(valid_categories)}"}


### PR DESCRIPTION
## Summary

Two small fixes in `mcp_server/server.py`:

1. `search_knowledge(category="general")` was rejected as "Invalid category" even though documents with that category exist in the index — the parser assigns `"general"` as a fallback when no `category_mapping` path matches.

2. When BM25 returns a `chunk_id` that Chroma can no longer resolve (stale after reindex), the code serialized a record with empty `document` and `metadata` fields instead of skipping it.

Closes # (no issue — discovered during local usage)

## Type of change

- [x] fix — bug fix
- [ ] feat — new feature
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] perf — performance improvement
- [ ] test — adding or improving tests
- [ ] chore — tooling, deps, CI
- [ ] BREAKING CHANGE (explain in Migration section below)

## What changed

- `mcp_server/server.py:2276` — added `"general"` to `valid_categories` list
- `mcp_server/server.py:1546-1548` — skip BM25-only result if Chroma returns empty document/metadata; simplified data construction since guard ensures non-empty

## Why

Both are real bugs encountered during everyday use:

- **general category**: the `_detect_category` parser returns `"general"` as fallback for any file whose path doesn't match a `category_mapping` entry. Calling `search_knowledge(category="general")` should work, but validation rejects it because `"general"` isn't in `keyword_routes` or `category_mappings`.
- **empty BM25 results**: after reindex, Chroma chunk_ids change but the lazy-built BM25 index keeps stale IDs. The fallback `collection.get()` returned empty lists, and the code created a result entry with empty strings instead of skipping it.

The `"general"` approach is the simplest fix — it's a first-class category name used internally. An alternative would be to derive `valid_categories` from the live index, but that requires the orchestrator to be initialized before validation, complicating the error-reporting path.

---

## 7 Pillars Quality Gate

### 1. Security

- [x] No new secrets, tokens, or credentials in the diff
- [x] No new use of `eval`, `exec`, `subprocess shell=True`, `pickle.loads` on untrusted input, or arbitrary deserialization
- [x] New dependencies (if any) reviewed for known CVEs and license compatibility — no new dependencies
- [x] Path traversal, command injection, and SSRF surfaces explicitly considered for any new I/O code — no new I/O code

### 2. Stability

- [x] All existing tests still pass on Linux + Windows × Python 3.11/3.12 — verified: `pytest tests/ -q` = 56 passed
- [x] New behavior covered by tests; tests are deterministic — covered by existing test infrastructure (no new tests needed for these trivially guarded paths)
- [x] Coverage does not regress — no uncovered branches added
- [x] No tests were skipped, deleted, or marked `xfail` to make the PR pass

### 3. Memory leak

- [x] Long-lived objects bounded — no new data structures
- [x] New caches have eviction policy — no new caches
- [x] No new global state that grows unbounded with usage
- [x] Lazy initialization considered — `get_orchestrator()` already lazy

### 4. Versatility

- [x] Works on Linux, Windows, macOS — pure Python, no platform-specific code
- [x] Works on Python 3.11, 3.12, 3.13 — no version-specific syntax
- [x] No hardcoded paths, locales, or encodings — unchanged
- [x] Parser not touched — only search and validation

### 5. Scalability

- [x] No O(n²) or worse algorithms on user-controlled inputs
- [x] Benchmark impact considered — negligible: one string in a list, one early-continue on a rare stale path
- [x] No perf regression — diff is +5 -3 lines, no loops or allocations added
- [x] Concurrency safety: no new shared mutable state

**Performance impact** (required — both changes in `mcp_server/server.py`):

```
metric          before    after    delta
search p95      —         —        negligible (< 0.1%)
index docs/sec  —         —        unchanged
RSS @ 1k docs   —         —        unchanged
```

### 6. Versioning

- [ ] If this is user-facing change: bumped version — [N/A] trivial bugfix, version bump not required for this scope
- [ ] If this is a breaking change: bumped MAJOR — N/A
- [ ] CHANGELOG updated with entry under `## Unreleased` — not updated (maintainer preference)
- [x] Public API surface unchanged — `search_knowledge` signature identical

### 7. Quality

- [x] `ruff check` passes — verified
- [x] `ruff format --check` passes — no formatting changes
- [x] Type hints on new public functions — no new public functions
- [x] Docstrings on new public functions — no new public functions
- [x] Cyclomatic complexity reasonable — no new branches beyond guard
- [x] No dead code — removed dead fallback-to-empty-string paths
- [x] PR is reasonably sized — 8 lines of diff (5 insertions, 3 deletions)

## Migration / Breaking changes

N/A

## Test plan

- [x] `pytest tests/ -q` passed locally — 56 passed
- [ ] `pre-commit run --all-files` clean — N/A (no pre-commit config in repo)
- [x] Manual smoke test: `search_knowledge(category="general")` returns results instead of "Invalid category" error; verified on live index

## Documentation

- [ ] Updated `README.md` — N/A, internal bugfix
- [ ] Updated `docs/` — N/A
- [ ] Added entry to `## Unreleased` in README CHANGELOG section — N/A, maintainer will add if desired

## Reviewer checklist

<!-- Do not edit. The reviewer fills this. -->

- [ ] Reviewed line-by-line
- [ ] Verified the 7 pillars CI status checks are green
- [ ] Verified no obvious adversarial implications
- [ ] Approved performance impact

---

By submitting this PR I confirm I read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).
