### PR TITLE
chore(release): v4.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1401,8 +1401,12 @@ Common issues:
 
 ### Unreleased
 
-- **FIX**: Accept `"general"` as a valid category in `search_knowledge` — the parser fallback was missing from `valid_categories`.
-- **FIX**: Skip BM25-only search results when Chroma can no longer resolve the chunk ID (stale after reindex) instead of returning records with empty fields.
+### v4.3.1 (2026-06-22) — Hybrid Search Fixes
+
+- **FIX**: Accept `"general"` as a valid category in `search_knowledge`. The parser hardcodes `"general"` as the fallback in `_detect_category` (`ingestion.py`), but the validator only built `valid_categories` from `config.keyword_routes` + `config.category_mappings.values()` — so users who customized `config.yaml` and dropped the default `"general": "general"` mapping hit `Invalid category` even though the index contained `general` documents. Validator now always tolerates `"general"`. (#98, thanks @Hohlas)
+- **FIX**: Skip BM25-only search results when Chroma can no longer resolve the chunk ID. Stale BM25 indices (typically right after `remove_document` or in the window between async reindex and BM25 rebuild) returned hits whose `collection.get()` came back empty; the previous fallback inserted entries with `document=""` / `metadata={}` into the reranker, polluting results with empty matches. The pipeline now `continue`s past those, dropping the stale hit cleanly. (#98, thanks @Hohlas)
+- **TEST**: Added `tests/test_pr98_regression.py` (4 tests) pinning both contracts so future refactors cannot silently revert either fix. Test count baseline: 227 → 231. (#99)
+- **CI**: Bumped `[tool.mypy] python_version` from 3.11 to 3.12 to accept PEP 695 `type` statements in the numpy stub (`numpy/__init__.pyi`) which were breaking the Pillar 7 strict gate. Only affects static analysis; `requires-python = ">=3.11"` unchanged. (#100)
 
 ### v4.3.0 (2026-06-17) — Async Reindex, GPU CUDA 12, 13th MCP Tool
 

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -8,7 +8,7 @@ import sys  # noqa: I001
 _original_stdout = sys.stdout
 sys.stdout = sys.stderr
 
-__version__ = "4.3.0"
+__version__ = "4.3.1"
 __author__ = "Ailton Rocha (Lyon.)"
 
 from .config import Config  # noqa: E402

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-rag",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 13 MCP Tools + 20 Format Parsers. Zero external servers.",
   "bin": {
     "knowledge-rag": "./bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "knowledge-rag"
-version = "4.3.0"
+version = "4.3.1"
 description = "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 13 MCP Tools + 20 Format Parsers. Zero external servers."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## v4.3.1 — Hybrid Search Fixes

PATCH release rolling up today's hybrid-search bug fixes (#98 from external contributor @Hohlas), the anti-regression suite that pins them (#99), and the mypy CI unblocker (#100).

### User-facing fixes

- **\`search_knowledge(category="general")\`** no longer returns \`Invalid category\` when the user has customized \`category_mappings\` to drop the default \`"general": "general"\` entry. The parser hardcodes \`"general"\` as the fallback in \`ingestion.py:_detect_category\`, so the validator must always tolerate it.  *(#98)*
- **Stale BM25 chunk IDs** no longer leak into results. When BM25 returned a chunk ID that Chroma could no longer resolve (right after \`remove_document\` or in the window between async reindex and BM25 rebuild), the fallback path injected a record with empty \`document\` and \`metadata\` into the reranker. Pipeline now \`continue\`s past the stale ID cleanly.  *(#98)*

### Internal

- **Tests**: \`tests/test_pr98_regression.py\` (4 tests) pin both contracts. Validated by reverting each fix locally — 3/4 fail as designed (the 4th is a defensive control).  *(#99)*
- **CI**: \`[tool.mypy] python_version\` bumped from 3.11 → 3.12 to accept PEP 695 \`type\` statements in the numpy stub. Only governs static analysis; \`requires-python = ">=3.11"\` is unchanged.  *(#100)*

### Version bumps (atomic)

| File | 4.3.0 → 4.3.1 |
|------|-----|
| \`pyproject.toml\` | ✓ |
| \`mcp_server/__init__.py\` | ✓ |
| \`npm/package.json\` | ✓ |

\`check_version_sync.py\` → \`[OK] All three version declarations agree: 4.3.1\`

### Backwards compatibility

\`check_api_surface.py --check\` → \`[OK] No breaking changes to public API surface.\`

13 MCP tools frozen, all parameter signatures identical.

### Quality Gate

- 9-cell test matrix (Linux + Windows + macOS × Python 3.11/3.12/3.13)
- All 7 pillars
- \`skip-perf-gate\` applied per release-PR convention (RSS jitter on micro-bench is documented)

### After merge

\`gh release create v4.3.1 --target master --generate-notes\` → triggers \`release.yml\` → PyPI + NPM + Docker auto-publish.