### PR TITLE
fix: apply category filter to BM25 hybrid search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1410,6 +1410,7 @@ Common issues:
 - **FIX**: `install.sh` guards against `sh install.sh` (bash-only features now emit a clear error instead of a cryptic syntax failure).
 - **FIX**: Both scripts now correctly advertise **13 MCP tools** (was outdated at 12; `get_reindex_status` shipped in v4.3.0).
 - **FIX**: Windows-side `install.ps1` prefers `winget install Python.Python.3.12 --scope user` (no admin), falls back to python.org 3.12.7 (was pinned to 3.12.0).
+- **FIX**: Hybrid search now applies the active category filter to BM25 results before RRF fusion, preventing keyword-only hits from other categories from leaking into filtered searches.
 - **TEST**: New `tests/test_installer_no_data_loss.py` (22 tests) locks in the installer's zero-data-loss contract across all three JSON schemas (`mcpServers` / `servers` / `context_servers`): top-level keys preserved, sibling MCP servers byte-identical, `.knowledge-rag.bak` backup written before every mutation, idempotent second run, `--dry-run` writes nothing, atomic `os.replace` write. Baseline: 231 → 266.
 
 ### v4.3.1 (2026-06-22) — Hybrid Search Fixes

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1474,6 +1474,12 @@ class KnowledgeOrchestrator:
         elif routed_category:
             where_filter = {"category": routed_category}
 
+        def _matches_category(metadata: Dict[str, Any]) -> bool:
+            if not where_filter:
+                return True
+            expected_category = where_filter.get("category")
+            return not expected_category or metadata.get("category") == expected_category
+
         # Parallel Semantic + BM25 search (threaded for latency reduction)
         from concurrent.futures import ThreadPoolExecutor
 
@@ -1507,8 +1513,23 @@ class KnowledgeOrchestrator:
             r = {}
             if hybrid_alpha < 1.0:
                 try:
-                    bm25_hits = self.bm25_index.search(query_text, top_k=max_results * 3)
-                    for rank, (chunk_id, bm25_score) in enumerate(bm25_hits):
+                    bm25_top_k = max_results * (20 if where_filter else 3)
+                    bm25_hits = self.bm25_index.search(query_text, top_k=bm25_top_k)
+
+                    if where_filter:
+                        chunk_ids = [chunk_id for chunk_id, _ in bm25_hits]
+                        metadata_by_id = {}
+                        if chunk_ids:
+                            fetched = self.collection.get(ids=chunk_ids, include=["metadatas"])
+                            metadata_by_id = dict(zip(fetched.get("ids", []), fetched.get("metadatas", [])))
+
+                        bm25_hits = [
+                            (chunk_id, bm25_score)
+                            for chunk_id, bm25_score in bm25_hits
+                            if _matches_category(metadata_by_id.get(chunk_id, {}))
+                        ]
+
+                    for rank, (chunk_id, bm25_score) in enumerate(bm25_hits[: max_results * 3]):
                         r[chunk_id] = {"rank": rank + 1, "bm25_score": bm25_score}
                 except Exception as e:
                     print(f"[WARN] BM25 search failed: {e}")
@@ -1557,6 +1578,9 @@ class KnowledgeOrchestrator:
                     }
                 except Exception:
                     continue
+
+            if not _matches_category(data.get("metadata", {})):
+                continue
 
             combined_scores[chunk_id] = {
                 "rrf_score": combined_rrf,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,7 +1,7 @@
 """Tests for search pipeline components (no model/DB required)."""
 
 from mcp_server.config import _merge_query_expansion_sources
-from mcp_server.server import BM25Index, QueryCache
+from mcp_server.server import BM25Index, KnowledgeOrchestrator, QueryCache
 
 # ── BM25 Query Expansion ──
 
@@ -123,6 +123,65 @@ class TestBM25Search:
         bm25.build_index()
         results = bm25.search("")
         assert results == []
+
+
+class TestHybridCategoryFilter:
+    def test_bm25_results_respect_category_filter(self, monkeypatch):
+        """BM25-only results must not bypass an explicit category filter."""
+        monkeypatch.setattr("mcp_server.server.config.reranker_enabled", False)
+
+        class FakeCache:
+            def get(self, *args, **kwargs):
+                return None
+
+            def put(self, *args, **kwargs):
+                return None
+
+        class FakeBM25:
+            def search(self, query, top_k):
+                return [("chunk_report", 10.0), ("chunk_code", 9.0)]
+
+        class FakeCollection:
+            _docs = {
+                "chunk_report": "report content",
+                "chunk_code": "code content",
+            }
+            _metadatas = {
+                "chunk_report": {
+                    "source": "/docs/report.md",
+                    "filename": "report.md",
+                    "category": "reports",
+                    "chunk_index": 0,
+                    "keywords": "",
+                },
+                "chunk_code": {
+                    "source": "/src/code.py",
+                    "filename": "code.py",
+                    "category": "code",
+                    "chunk_index": 0,
+                    "keywords": "",
+                },
+            }
+
+            def get(self, ids, include):
+                return {
+                    "ids": ids,
+                    "documents": [self._docs[chunk_id] for chunk_id in ids] if "documents" in include else None,
+                    "metadatas": [self._metadatas[chunk_id] for chunk_id in ids] if "metadatas" in include else None,
+                }
+
+        orchestrator = object.__new__(KnowledgeOrchestrator)
+        orchestrator.query_cache = FakeCache()
+        orchestrator.bm25_index = FakeBM25()
+        orchestrator.collection = FakeCollection()
+        orchestrator._ensure_bm25_index = lambda: None
+        orchestrator._route_by_keywords = lambda query: None
+        orchestrator._expand_with_adjacent_chunks = lambda results: results
+
+        results = orchestrator.query("anything", max_results=5, category_filter="reports", hybrid_alpha=0.0)
+
+        assert [result["source"] for result in results] == ["/docs/report.md"]
+        assert {result["category"] for result in results} == {"reports"}
 
 
 # ── Query Cache ──


### PR DESCRIPTION
Hi @lyonzin,

Thanks again for maintaining `knowledge-rag`. This is a small follow-up PR from real-world usage of the hybrid search/category filtering path.

## Summary

Fixes inconsistent category filtering in hybrid search: semantic search already respected `category`, but BM25 keyword results were searched across the full index and then fused back into the final result set. This could return documents from other categories even when the caller explicitly requested a category filter.

Closes N/A

## Type of change

- [ ] feat - new feature
- [x] fix - bug fix
- [ ] docs - documentation only
- [ ] refactor - no behavior change
- [ ] perf - performance improvement
- [x] test - adding or improving tests
- [ ] chore - tooling, deps, CI
- [ ] BREAKING CHANGE (explain in Migration section below)

## What changed

- `mcp_server/server.py`: apply the active category filter to BM25 hits before RRF fusion.
- `mcp_server/server.py`: add a final category guard before adding fused results.
- `tests/test_search.py`: add a deterministic regression test covering BM25-only results with mixed categories.

## Why

When `search_knowledge(..., category="reports")` is used, users expect all returned results to belong to `reports`. Before this change, only the semantic ChromaDB query received the category filter. BM25 results were retrieved globally and could reintroduce chunks from other categories during RRF fusion.

The fix keeps the existing public API and ranking model unchanged. It only ensures that all search branches respect the same active category filter.

---

## 7 Pillars Quality Gate

> Mark each item. CI enforces these via the `quality-gate.yml` workflow.

### 1. Security

- [x] No new secrets, tokens, or credentials in the diff (gitleaks will block)
- [x] No new use of `eval`, `exec`, `subprocess shell=True`, `pickle.loads` on untrusted input, or arbitrary deserialization
- [x] New dependencies (if any) reviewed for known CVEs and license compatibility
- [x] Path traversal, command injection, and SSRF surfaces explicitly considered for any new I/O code

### 2. Stability

- [ ] All existing tests still pass on Linux + Windows x Python 3.11/3.12
- [x] New behavior covered by tests; tests are deterministic (no `time.sleep` / network / OS-scheduler dependencies)
- [ ] Coverage does not regress (codecov gate)
- [x] No tests were skipped, deleted, or marked `xfail` to make the PR pass

### 3. Memory leak

- [x] Long-lived objects (orchestrator, watcher, cache) are bounded
- [x] New caches have eviction policy (LRU, TTL, or explicit size limit)
- [x] No new global state that grows unbounded with usage
- [x] If you added a new module that loads heavy resources, consider lazy initialization

### 4. Versatility

- [x] Works on Linux, Windows, macOS (paths, line endings, locale considered)
- [x] Works on Python 3.11, 3.12, 3.13 (no Python-version-specific syntax without fallback)
- [x] No hardcoded paths, locales, or encodings (use `pathlib.Path`, `encoding="utf-8"` explicit)
- [x] If you touched a parser, all 20 supported formats still parse correctly

### 5. Scalability

- [x] No O(n^2) or worse algorithms on user-controlled inputs
- [ ] Benchmark impact considered (run `pytest bench/` locally if you touched search/index/embed)
- [x] If perf regression > 10% in any metric, justification provided below
- [x] Concurrency safety: no new shared mutable state without lock or documented thread confinement

**Performance impact** (required if you touched `mcp_server/server.py`, `mcp_server/ingestion.py`, or `bench/`):

```text
metric          before    after    delta
search p95      N/A       N/A      N/A
index docs/sec  N/A       N/A      N/A
RSS @ 1k docs   N/A       N/A      N/A
```

This change only adds metadata filtering for BM25 candidates when a category filter is active. It fetches metadata for an expanded BM25 candidate pool only in that filtered path. I did not run the benchmark suite locally.

### 6. Versioning

- [ ] If this is user-facing change: bumped version in `pyproject.toml`, `mcp_server/__init__.py`, and `npm/package.json` atomically
- [ ] If this is a breaking change: bumped MAJOR, added migration notes in CHANGELOG, marked `BREAKING CHANGE:` in commit footer
- [ ] CHANGELOG updated with entry under `## Unreleased` in README.md
- [x] Public API surface (`mcp_server/server.py` MCP tool decorators) unchanged, OR breaking changes documented

### 7. Quality

- [ ] `ruff check` passes
- [ ] `ruff format --check` passes
- [x] Type hints on new public functions (`mypy --strict` clean for new files)
- [x] Docstrings on new public functions (used by `interrogate`)
- [x] Cyclomatic complexity reasonable (`radon cc --max=C`)
- [x] No dead code (`vulture` would not flag new code)
- [x] PR is reasonably sized (< 500 lines of diff preferred; bigger PRs split or justify)

---

## Migration / Breaking changes

N/A. This is not a breaking change. It makes the existing `category` filter apply consistently to both semantic and BM25 branches of hybrid search.

## Test plan

- [ ] `pytest tests/ -v` passed locally
- [ ] `pre-commit run --all-files` clean
- [x] Manual smoke test: verified in a local indexed project that `search_knowledge(..., category="reports")` no longer returns results from other categories after restart.
- [x] Ran targeted test locally: `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest tests/test_search.py -q` -> `23 passed`.

## Documentation

- [ ] Updated `README.md` (if user-facing)
- [ ] Updated `docs/` (if applicable)
- [ ] Added entry to `## Unreleased` in README CHANGELOG section

## Reviewer checklist

<!-- Do not edit. The reviewer fills this. -->

- [ ] Reviewed line-by-line
- [ ] Verified the 7 pillars CI status checks are green
- [ ] Verified no obvious adversarial implications
- [ ] Approved performance impact

---

By submitting this PR I confirm I read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).
