### PR TITLE
chore(release): v4.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1401,6 +1401,8 @@ Common issues:
 
 ### Unreleased
 
+### v4.4.0 (2026-07-06) — Cross-Platform Installer & Hybrid Search Category Filter
+
 - **NEW**: Cross-platform, multi-LLM-client installer (`install.py`) driving both `install.sh` (Linux/macOS) and `install.ps1` (Windows) as thin wrappers. One codebase, one behavior across every OS.
 - **NEW**: Auto-detects and registers `knowledge-rag` in 8 LLM clients — Claude Code, Claude Desktop, Cursor, Windsurf, VS Code (Copilot Chat), Cline, Gemini CLI, Zed — writing to each tool's canonical config path with the correct JSON schema per client (VS Code uses `servers`, Zed uses `context_servers`, everyone else uses `mcpServers`).
 - **NEW**: `--for <clients>` / `--exclude <clients>` opt-in/opt-out selection, `--dry-run` preview, `--list-clients` registry inspection, `--pypi-version <ver>` pinning, `--skip-init` / `--skip-model` for fast reruns. See `python install.py --help`.
@@ -1410,8 +1412,9 @@ Common issues:
 - **FIX**: `install.sh` guards against `sh install.sh` (bash-only features now emit a clear error instead of a cryptic syntax failure).
 - **FIX**: Both scripts now correctly advertise **13 MCP tools** (was outdated at 12; `get_reindex_status` shipped in v4.3.0).
 - **FIX**: Windows-side `install.ps1` prefers `winget install Python.Python.3.12 --scope user` (no admin), falls back to python.org 3.12.7 (was pinned to 3.12.0).
-- **FIX**: Hybrid search now applies the active category filter to BM25 results before RRF fusion, preventing keyword-only hits from other categories from leaking into filtered searches.
+- **FIX**: Hybrid search now applies the active category filter to BM25 results before RRF fusion, preventing keyword-only BM25 hits from other categories from leaking into filtered searches. Both leak paths are closed: BM25 candidates are metadata-filtered before RRF (with `top_k` widened to `max_results * 20` to compensate for post-filter drop), and the fallback fetch during fusion re-checks `category` before adding a chunk to `combined_scores`. Note: the `category_filter` guard now also applies to the keyword-routed category — `_route_by_keywords()`-inferred routing filters BM25 too, consistent with the semantic branch. Users with warm `query_cache` entries should restart the server to invalidate stale results. (#109, thanks @Hohlas)
 - **TEST**: New `tests/test_installer_no_data_loss.py` (22 tests) locks in the installer's zero-data-loss contract across all three JSON schemas (`mcpServers` / `servers` / `context_servers`): top-level keys preserved, sibling MCP servers byte-identical, `.knowledge-rag.bak` backup written before every mutation, idempotent second run, `--dry-run` writes nothing, atomic `os.replace` write. Baseline: 231 → 266.
+- **TEST**: New `TestHybridCategoryFilter::test_bm25_results_respect_category_filter` in `tests/test_search.py` — deterministic regression covering BM25-only hits with mixed categories. Baseline: 266 → 267.
 
 ### v4.3.1 (2026-06-22) — Hybrid Search Fixes
 

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -8,7 +8,7 @@ import sys  # noqa: I001
 _original_stdout = sys.stdout
 sys.stdout = sys.stderr
 
-__version__ = "4.3.1"
+__version__ = "4.4.0"
 __author__ = "Ailton Rocha (Lyon.)"
 
 from .config import Config  # noqa: E402

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-rag",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 13 MCP Tools + 20 Format Parsers. Zero external servers.",
   "bin": {
     "knowledge-rag": "./bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "knowledge-rag"
-version = "4.3.1"
+version = "4.4.0"
 description = "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 13 MCP Tools + 20 Format Parsers. Zero external servers."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Minor bump bundling two independent streams that had accumulated in `## Unreleased`:

1. **Cross-platform installer** (from #108, merged 2026-07-04) — `install.py` orchestrator + thin `install.sh` / `install.ps1` wrappers, auto-registration in 8 LLM clients (Claude Code/Desktop, Cursor, Windsurf, VS Code, Cline, Gemini CLI, Zed) with per-client canonical JSON schema and zero-data-loss backup (`.knowledge-rag.bak`).
2. **Hybrid-search category filter fix** (from #109, merged 2026-07-05) — closes two leak paths where BM25 hits from other categories bypassed the active `category_filter`. See CHANGELOG for the full mechanism.

**Semver rationale:** installer is a NEW capability (per the v4.3.0 precedent) → MINOR bump. Consolidating both into a single release avoids the installer stream sitting in `## Unreleased` indefinitely.

## Changes

- `pyproject.toml`  `4.3.1` → `4.4.0`
- `mcp_server/__init__.py`  `4.3.1` → `4.4.0`
- `npm/package.json`  `4.3.1` → `4.4.0`
- `README.md` — moved 11 entries from `## Unreleased` into new `### v4.4.0 (2026-07-06)` section; enriched the BM25 fix line with implementation notes + `@Hohlas` credit
- `## Unreleased` intentionally empty for the next cycle

## Local validation

- `python scripts/check_version_sync.py` → OK (`4.4.0` × 3)
- `python scripts/check_api_surface.py --check` → No breaking changes
- `python scripts/check_changelog.py --pr-title 'chore(release): v4.4.0'` → OK (chore exempt, but CHANGELOG populated anyway)
- `pytest tests/` → **261 passed / 5 deselected / 1 xfailed**
- `pytest tests/test_search.py::TestHybridCategoryFilter -v` → PASSED

## Post-merge plan

- `gh release create v4.4.0 --target master --generate-notes` → triggers `release.yml` → auto-publish to PyPI + NPM + GHCR Docker
- Verify publication on all three channels
- `pip install -e .` locally to sync editable install metadata

## 7 Pillars

All gates already validated on `master` when #108 and #109 merged individually; this PR is version metadata + changelog only. Perf gate label `skip-perf-gate` may be applied if the RSS baseline jitters on the release CI run (per policy in `~/.claude/agents/rag-maintainer.md`).