### PR TITLE
docs(readme): replace broken star-history embed with dynamic stars badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,15 @@ pip install knowledge-rag → restart Claude Code → search_knowledge("your que
 
 ---
 
-## Star History
+## Stars
 
 <div align="center">
 
-<a href="https://www.star-history.com/?repos=lyonzin%2Fknowledge-rag&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=lyonzin/knowledge-rag&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=lyonzin/knowledge-rag&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=lyonzin/knowledge-rag&type=date&legend=top-left" />
- </picture>
+<a href="https://github.com/lyonzin/knowledge-rag/stargazers">
+  <img alt="GitHub stars" src="https://img.shields.io/github/stars/lyonzin/knowledge-rag?style=for-the-badge&logo=github&color=yellow&labelColor=black" />
+</a>
+<a href="https://star-history.com/#lyonzin/knowledge-rag&Date">
+  <img alt="Star History" src="https://img.shields.io/badge/Star_History-View_Chart-blue?style=for-the-badge&logo=star" />
 </a>
 
 </div>


### PR DESCRIPTION
## Summary

Replace the embedded `api.star-history.com/chart` image (currently returning HTTP 404 for every visitor) with a dynamic shields.io stars badge plus a plain link to star-history.com. Renames the section from "Star History" to "Stars" since the temporal chart is no longer rendered inline.

Closes N/A (no tracking issue; documenting root cause below).

## Type of change

- [x] docs — documentation only

## What changed

- `README.md` lines 37-49: `<picture>` block replaced by two shields.io badges (`## Star History` → `## Stars`)

## Why

The current URL `https://api.star-history.com/chart?repos=lyonzin/knowledge-rag&type=date&legend=top-left` returns **HTTP 404** in every browser hitting the README.

**Root cause (verified against GitHub REST + star-history issue tracker):**

- GitHub restricted `/repos/{owner}/{repo}/stargazers` on **2026-06-30** to admins/collaborators of the target repo (see: https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/).
- Star-history's rotating pool of donated PATs stopped working overnight. Empty/404 charts across the ecosystem since **2026-07-01**.
- Public evidence of the outage:
  - star-history/star-history#539 — "[Ongoing] Empty star history chart due since July 1st, 2026" (still open, 21 comments)
  - star-history/star-history#542 — "The GitHub API's new restrictions almost killed this project" (still open)
- Even with a valid fine-grained token (`Metadata: Read-only`), `/stargazers` now returns `403 "Resource not accessible by personal access token"`. Only classic tokens with `public_repo` scope, or fine-grained tokens with a granular permission that star-history's dialog does not currently request, pass.
- Regenerating the embed with a `sealed_token` would work today for readers, but the pipeline is unstable (see #539) and the dependency is one API tweak away from re-breaking.

**Alternatives considered:**

- Regenerate the embed with a `sealed_token` via a classic PAT with `public_repo` scope. Rejected: still tied to a service with an active P0 issue and no ETA for a GitHub App migration.
- Delete the section entirely. Rejected: 15.9k+ downloads (pepy) + 70 enterprise users is real social proof; hero deserves a star signal.
- Static "N stars" text. Rejected: goes stale immediately.

**Chosen path:** shields.io GitHub stars badge (real-time count via GitHub public API, no auth) + a plain link to star-history.com for readers who want the temporal curve. When star-history recovers, the link still works. When it does not, the visitor sees star-history's own token dialog on their side, not a broken image on ours.

---

## 7 Pillars Quality Gate

Docs-only change; no code touched.

### 1. Security
- [x] No new secrets, tokens, or credentials in the diff
- [x] N/A — no code changed
- [x] No new dependencies
- [x] N/A — no I/O code

### 2. Stability
- [x] N/A — no code changed; all tests untouched
- [x] N/A
- [x] Coverage not affected
- [x] No tests modified

### 3. Memory leak
- [x] N/A — docs-only

### 4. Versatility
- [x] Markdown rendered by GitHub; badge URLs are protocol-relative-friendly and locale-agnostic
- [x] N/A
- [x] N/A
- [x] N/A — no parser touched

### 5. Scalability
- [x] N/A — docs-only

### 6. Versioning
- [x] Not user-facing behavior — no version bump needed (docs fix for broken third-party embed)
- [x] Not a breaking change
- [x] `skip-changelog` label applied — this is a docs fix for a broken external service, no product behavior changed
- [x] Public API surface unchanged

### 7. Quality
- [x] N/A — no Python touched (ruff/mypy/interrogate/radon/vulture do not apply)
- [x] PR size: 6 insertions, 7 deletions (README.md only)

---

## Migration / Breaking changes

N/A

## Test plan

- [x] Visual smoke test: rendered the README locally and on the branch tip via GitHub's web preview — badges load, both links resolve.
- [x] Verified new URLs return HTTP 200:
  - `https://img.shields.io/github/stars/lyonzin/knowledge-rag?...` → HTTP 200
  - `https://star-history.com/#lyonzin/knowledge-rag&Date` → HTTP 200
- [x] Verified old URL still returns HTTP 404 (confirms the root cause has not been silently fixed upstream): `https://api.star-history.com/chart?repos=lyonzin/knowledge-rag&type=date&legend=top-left` → HTTP 404

## Documentation

- [x] Updated `README.md` (the change)
- [x] N/A — `docs/` not affected
- [x] N/A — `skip-changelog` (not a product-behavior change)