### PR TITLE
chore(gitignore): ignore MagicMock/ dirs leaked by unspec'd Config mocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,10 @@ desktop.ini
 dist/
 .ruff_cache/
 .pytest_cache/
+
+# Filesystem leak: Path(MagicMock()) auto-invokes __fspath__ and creates
+# literal "MagicMock/<attr>/<id>" dirs on Windows. Any test that passes an
+# unspec'd MagicMock as a config-like object into a code path that resolves
+# Path(config.data_dir) reproduces. Preventive: use spec=Config or
+# types.SimpleNamespace when mocking config in tests.
+MagicMock/


### PR DESCRIPTION
## Summary

`Path(MagicMock())` on Windows silently succeeds because `MagicMock` auto-instruments `__fspath__`. Pathlib then turns the mock into a literal directory named `MagicMock/<attr>/<id>`. Any test that hands an unspec'd `MagicMock()` to a code path that eventually resolves `Path(config.data_dir)` writes persistent turds like:

```
MagicMock/config.data_dir/MagicMock/config.query_log_dir/<id>/
```

...under the repo root, where they accumulate silently across test runs.

## What this PR does

**Symptom-only fix**: adds `MagicMock/` to `.gitignore` so accidental leaks never enter git tracking.

## What this PR does NOT do

The root cause — tests handing bare `MagicMock()` to `config`-like arguments — will be fixed in a follow-up PR that audits the ~22 test files currently using unspec'd mocks and switches them to `spec=Config` or `types.SimpleNamespace`, so `__fspath__` no longer resolves silently.

Listing (via grep for `MagicMock\(\)`):

- tests/test_hyde.py, test_self_query.py, test_confidence_labels.py, test_dashboard.py, test_multi_query.py, test_global_index.py, test_query_rewrite.py, test_truncation.py, test_cli.py, test_llm_provider_registry.py, test_mmr.py, test_parent_document.py, test_provider_registry.py, test_pr114_regression.py, test_pr98_regression.py, test_tools.py, test_memory_baseline.py, test_lazy_embeddings.py
- tests/security/test_path_traversal.py, test_prompt_injection.py
- tests/chaos/test_onnx_zero_byte.py
- tests/conftest.py

## Reproduction

```python
from unittest.mock import MagicMock
from pathlib import Path
Path(MagicMock()).mkdir(parents=True, exist_ok=True)
# -> creates "MagicMock/mock/<id>/" on Windows, no exception raised
```

## Test plan

- [x] `.gitignore` entry added; existing rules untouched
- [x] No behavioural code changed; test suite unaffected
- [ ] CI Quality Gate passes (7 pilares + 9-cell OS×Python matrix)