### PR TITLE
docs(readme): resolve OpenSSF Best Practices badge to real project ID (13864)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![CodeQL](https://github.com/lyonzin/knowledge-rag/actions/workflows/security.yml/badge.svg)](https://github.com/lyonzin/knowledge-rag/actions/workflows/security.yml)
 [![Quality Gate](https://github.com/lyonzin/knowledge-rag/actions/workflows/quality-gate.yml/badge.svg)](https://github.com/lyonzin/knowledge-rag/actions/workflows/quality-gate.yml)
 [![Glama Score](https://glama.ai/mcp/servers/lyonzin/knowledge-rag/badges/score.svg)](https://glama.ai/mcp/servers/lyonzin/knowledge-rag)
-[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/XXXX/badge)](https://bestpractices.coreinfrastructure.org/projects/XXXX)
+[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/13864/badge)](https://bestpractices.coreinfrastructure.org/projects/13864)
 
 ### Your docs, your machine, zero cloud. Claude Code searches them natively.
 


### PR DESCRIPTION
## Summary

Registers the project at https://www.bestpractices.dev and replaces the XXXX placeholder in the README badge URL with the real project ID **13864**.

Badge now resolves to: **https://www.bestpractices.dev/en/projects/13864**

## Passing-level criteria status at time of registration

| Section | Score |
|---|---|
| Basics | **13/13** |
| Change Control | **9/9** |
| Reporting | **8/8** |
| Quality | **13/13** |
| Security | **16/16** |
| Analysis | **8/8** |
| **Overall** | **100% — PASSING badge attributed** |

## What was done

1. Created the project at bestpractices.dev via GitHub OAuth (auto-imported repo metadata).
2. Filled all 67 criteria using the evidence pack that already ships in `.github/openssf-best-practices.md`.
3. Every criterion links back to concrete artefacts in this repo (workflows, docs, ADR, security.py, etc.).
4. Replaced `XXXX` → `13864` in the README badge URL (1 line change).

## Next steps (roadmap, not this PR)

- **Silver level** (~30–40 additional criteria): most items are already in place per the evidence pack (`### 2.x — Silver`). Test coverage climb to 80% (currently 35% baseline) is the main open item.
- **Gold level** (~15 more): SBOM per release, coverage-guided fuzzing (atheris), multiple maintainers, GOVERNANCE.md expansion.

## Test plan

- [x] Badge URL changes are byte-identical in shape (only the numeric ID changed)
- [x] No other files touched
- [ ] CI Quality Gate passes (7 pillars + 9-cell OS × Python matrix)
- [ ] Badge visually resolves to a real green shield on the rendered README (verify after merge on GitHub)