### PR TITLE
docs(readme): promote v4.6.0 MCP spec 2026-07-28 migration to What's New section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,21 @@ pip install knowledge-rag → restart Claude Code → search_knowledge("your que
 
 ---
 
-## What's New in v4.2.0
+## What's New in v4.6.0
+
+### MCP spec 2026-07-28 via Anthropic Tier 1 SDK (v4.6.0)
+
+Adopts the [**MCP spec 2026-07-28**](https://blog.modelcontextprotocol.io/posts/2026-07-28/) — stateless request/response core, per-request `_meta.io.modelcontextprotocol/protocolVersion` + `clientCapabilities`, `serverInfo` on every response, retirement of the `initialize`/`initialized` handshake and the `Mcp-Session-Id` header. Delivered by moving directly to the **Anthropic Tier 1 Python SDK** (`mcp>=2.0.0,<3.0.0`, published 2026-07-28).
+
+**What changed under the hood**:
+- `mcp>=1.6.0,<2.0.0` → **`mcp>=2.0.0,<3.0.0`**
+- `from mcp.server.fastmcp import FastMCP` → `from mcp.server import MCPServer`
+- `FastMCP(name, host=, port=)` → `MCPServer(name, version="4.6.0")` — `host` / `port` moved to `mcp.run(transport=..., host=..., port=...)` on non-stdio transports (per v2 API)
+- Server now advertises `version` in `serverInfo`, matching the 2026-07-28 spec recommendation
+
+**Zero user-facing changes** — `@mcp.tool()` / `@mcp.resource()` / `@mcp.prompt()` decorator ergonomics are unchanged. All 13 MCP tool signatures frozen. **stdio users see zero behaviour change**. Existing clients (Claude Code, Claude Desktop, Cursor, Windsurf, VS Code Copilot, Cline, Gemini CLI, Zed) negotiate the spec version per request and continue to work.
+
+**Why the Tier 1 SDK and not the third-party `fastmcp` package**: an early experiment with jlowin's [`fastmcp`](https://gofastmcp.com) tripped the Pillar 5 perf gate — `test_bench_orchestrator_idle_rss` +21.9% and `test_bench_query_cache_5000_entries` +17.1% RSS from the ~20 transitive deps its `[client,server]` extras pull in. Cutting the extras broke `@mcp.tool()` at runtime. Anthropic's `mcp 2.x` is the direct upstream reference — no third-party intermediary, no dependency bloat. Full details in the [v4.6.0 changelog entry](#v460-2026-07-30--mcp-spec-2026-07-28-via-anthropic-tier-1-sdk-mcp-2x) and closed PR #134.
 
 ### Search Performance & Output Quality (v4.2.0)
 


### PR DESCRIPTION
## Summary

The README's top-of-file **"What's New in v4.2.0"** section still headlines the 128× BM25 speedup from July. Now that v4.6.0 has shipped with the MCP spec 2026-07-28 migration, this PR promotes the migration to the top and renames the section header accordingly.

**Docs-only** — no code, no dep, no version bump.

## What changed

- `## What's New in v4.2.0` → `## What's New in v4.6.0`
- New leading subsection: `### MCP spec 2026-07-28 via Anthropic Tier 1 SDK (v4.6.0)`
- Historical subsections (v4.2.0 BM25, v4.0.0 SSE transport, Quality Gate, v3.8.1 hotfix, v3.8.0 lazy embeddings, single-instance guard, 5 ways to install) preserved unchanged under the new header

Diff: **+15 / -1** in `README.md`.

## Why `skip-changelog`

No user-facing behaviour change — v4.6.0 already ships its own CHANGELOG entry (added in #135). This PR is copywriting on the marquee only, no separate CHANGELOG entry is warranted.

## Test plan

- [ ] CI green (Lint & Format + PR title check + PR size guard + `skip-changelog` bypass)

---

## ⚠️ Pillar 5 bypass — RSS jitter, not real regression

Pillar 5 flagged **1 bench out of 12**: `test_bench_orchestrator_idle_rss` median 0.15 → 0.17 (**+11.6%**, only 1.6pp above the 10% gate).

**Why this is jitter, not real regression**:
- This PR is **docs-only** — 15 lines of README.md changed, **zero Python code**, **zero deps**, **zero config**.
- Master (post-#135, same code branched from) passed Pillar 5 clean (37/37 checks).
- The bench compares master vs branch of *identical code*. Any delta > 0 is CI-runner variance in RSS measurement (garbage collection timing, page-cache state, host neighbor noise).
- Other 11 benches passed within threshold.

Applying `skip-perf-gate` label per the documented bypass contract (see [CONTRIBUTING.md](CONTRIBUTING.md)#bypass-labels).