### PR TITLE
chore(release): v4.8.2 — FTS5 Lexical Fast-Path opt-in (default OFF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1252,6 +1252,27 @@ This keeps backward compatibility while allowing concise synonym groups.
 | 0.7 | Semantic-heavy | Conceptual queries, related topics |
 | 1.0 | Pure semantic | "How to..." questions, abstract concepts |
 
+### Search Method (v4.8.2+)
+
+Two paths ship with v4.8.2 — the default `hybrid` path (BM25 + semantic + RRF
++ optional rerank) that has been the sole path since v4.0, and an opt-in
+`fts5` lexical fast-path optimised for exact identifier queries (CVEs, MITRE
+ATT&CK codes, CWEs, file hashes, bug-bounty IDs). Enable via
+`search.lexical_fast_path.enabled: true` in `config.yaml`.
+
+| Method                  | Path              | Latency (typical)     | Best For                                     |
+|-------------------------|-------------------|-----------------------|----------------------------------------------|
+| `auto` **(default)**    | Router decides    | Router adds ~0.1ms    | Mixed workloads — safe default               |
+| `hybrid`                | BM25 + semantic   | 50-150ms (with rerank)| Prose queries, "how does X work", exploration|
+| `fts5`                  | SQLite FTS5 only  | <10ms cold / <2ms hot | CVE / MITRE / CWE / hash lookups             |
+
+The `search_knowledge` MCP tool exposes `search_method: Literal["auto",
+"hybrid", "fts5"] = "auto"` (ADR-006, additive on the LEI 1 contract). The
+default `enabled: false` preserves v4.8.1 behaviour byte-for-byte; the flip
+to `enabled: true` by default is reserved for v4.9.0 pending the CI
+perf-gate adjudication documented in ADR-004 and ADR-009. Full user guide
+in [`docs/features/fts5_fast_path.md`](docs/features/fts5_fast_path.md).
+
 ---
 
 ## Project Structure
@@ -1414,6 +1435,38 @@ Common issues:
 
 ### Unreleased
 
+### v4.8.2 (2026-08-10) — FTS5 Lexical Fast-Path Opt-In Release (default OFF)
+
+v4.8.2 bundles Fases 1–5 of the FTS5 Lexical Fast-Path plan
+(`.compozy/tasks/fts5-lexical-fast-path/`) as an **opt-in** release —
+`search.lexical_fast_path.enabled` remains `false` by default, so users
+who do not touch `config.yaml` keep v4.8.1 behaviour byte-for-byte
+(LEI 1 preserved). The v4.9.0 default flip is deferred to the CI
+perf-gate adjudication documented in ADR-009 (bench harness ships in
+this release; the flip PR follows once G1 ≥15× and G2 ≤2% both pass on
+CI hardware).
+
+- **DOCS (search)**: new `docs/features/fts5_fast_path.md` user guide
+  covering overview / quick-start / 5-key config reference / how it
+  works / 5 troubleshooting scenarios / when-to-use guidance. README
+  Configuration section cross-links it.
+- **NEW (bench)**: `bench/test_bench_fts5_lexical.py` ships the
+  BENCH-001 (cold, p95 ≤ 10ms target) + BENCH-002 (hot, p95 ≤ 2ms
+  target) harness against a self-contained 3865-row FTS5 corpus. The
+  gate G2 comparison against `bench/test_bench_search.py` is executed
+  by CI per `.compozy/tasks/fts5-lexical-fast-path/bench_v4_9_0_gate.md`;
+  the two-round A/B was not run locally because the release-authoring
+  workstation cannot fairly baseline against CI hardware (ADR-004
+  §Risks).
+- **DOCS (adr)**: new ADR-009 documenting why the ADR-004 gate is
+  deferred to the CI perf-gate step and what conditions unlock the
+  v4.9.0 flip PR.
+- **CHANGE (config)**: `config.example.yaml` uncomments the
+  `search.lexical_fast_path.*` block so new users see the full
+  configuration surface (still `enabled: false`). Existing installs
+  are unaffected.
+- **VERSION**: 4.8.1 → **4.8.2** (PATCH — opt-in infrastructure + docs,
+  zero behaviour change on the default install).
 - **feat (search)**: FTS5 lazy background migration for existing corpus + CRUD sync (ADR-008). `Fts5LexicalIndex` gains `add_document`/`update_document`/`remove_document` (SQL INSERT/DELETE under `_fts5_lock`, incremental — diverges from BM25's full-rebuild pattern because FTS5 mutations are O(1) native SQL) and `start_migration_background(chunk_iter_factory, docs_total, resume_from=0, on_progress=...)` (daemon thread that persists checkpoint every 100 rows into the marker file). On daemon startup, `_maybe_start_fts5_migration` reads the marker: `complete` = fast-path live, `in_progress` = resume from `docs_indexed`, `failed`/missing = start fresh migration; queries during migration fall back to hybrid + emit `fast_path_fallback_total{reason="disabled"}`. `KnowledgeOrchestrator.{add,update,remove}_document_*` gain best-effort FTS5 sync hooks after the BM25 rebuild — errors are caught, logged, and counted (`fast_path_errors_total{error_class="Fts5CrudSyncError"}`) but never propagate to the CRUD tool (upstream write must keep succeeding). `nuclear_rebuild` and `_rebuild_bm25_post_swap` drop the FTS5 db + WAL/SHM/marker and dispatch a fresh migration from the swapped-in Chroma corpus. Two Prometheus gauges expose migration progress (`knowledge_rag_fast_path_migration_docs_indexed`, `_docs_total`). Standalone rebuild helper `scripts/build_fts5_index.py --data-dir <path> [--force] [--foreground] [--verbose]` for operator-driven repair. Operational runbook in `docs/runbooks/fts5_migration.md` covering enable / wait / verify / manual rebuild / large-corpus caveat. New coverage: `tests/test_fts5_migration.py` (17 tests — TestMigrationLifecycle UT-043..048, TestCRUDSync UT-049..052, TestMigrationIntegration IT-021..023, TestCRUDSyncIntegration IT-CRUD-001..004) + `tests/test_e2e_fts5.py::test_e2e006_forced_fts5_with_migration_pending_raises` (E2E-006). Fase 4 of the FTS5 Lexical Fast-Path plan.
 - **NEW (search)**: Optional cross-encoder rerank toggle on the FTS5 fast-path via `search.lexical_fast_path.rerank_enabled` (default `false` — see ADR-003 for rationale). When `true`, `KnowledgeOrchestrator._run_fts5_search` layers `CrossEncoderReranker.rerank` on top of the FTS5 results before adjacent-chunk expansion; result items keep `search_method="fts5"` (rerank is a rescorer, not a path change) and `reranker_score` is populated. When `false`, the `knowledge_rag_fast_path_rerank_skipped_total` counter increments and the fast-path stays under the <10ms lexical latency budget. Empirical basis: Flash-Rerank MiniLM-L-6-v2 CPU ≈72ms/100 docs vs the <10ms target — keeping rerank OFF by default is the correct trade-off; opt in only when recall on lexical queries matters more than latency. New coverage: `tests/test_search.py::TestRerankToggle` (UT-062, UT-063, IT-024, IT-025). Fase 3.5 of the FTS5 Lexical Fast-Path plan.
 - **NEW (search)**: FTS5 lexical fast-path dispatch wired inside `KnowledgeOrchestrator.query()` behind the opt-in `search.lexical_fast_path.enabled` toggle (default `false` — v4.8.1 behavior byte-for-byte for users who don't touch config). When enabled, the query router (Fase 2) classifies each query; lexical queries dispatch to the FTS5 index (Fase 1) via a new `_maybe_dispatch_fts5` helper, semantic queries flow through the existing hybrid pipeline. Per ADR-003 the cross-encoder reranker is skipped on the fast-path (real opt-in toggle deferred to Task 04). Per ADR-006 the `search_knowledge` MCP tool gains one optional param `search_method: Literal["auto","hybrid","fts5"] = "auto"` — additive-safe on the LEI 1 backward-compat contract. Explicit `"fts5"` when the feature is disabled OR the index is not ready raises `Fts5NotReadyError` and the MCP wrapper surfaces it as a JSON error envelope with a `suggestion` field pointing at `search_method='auto'`. `QueryCache._make_key` gains a 5th `search_method` param so paths cannot share cache entries. `MetricsCollector` gains five FTS5 counters plus a bucketed latency histogram (`knowledge_rag_fast_path_hits_total{path}`, `..._fallback_total{reason}`, `..._latency_seconds`, `..._errors_total{error_class}`, `..._rerank_skipped_total`) exposed through `/metrics`. New coverage: `tests/test_search_method_override.py` (5 IT), `tests/test_metrics.py` (2 UT), `tests/test_e2e_fts5.py` (7 E2E), and extensions to `tests/test_search.py` (16 IT/UT — dispatch, config toggle, cache key, metrics scrape), `tests/test_backwards_compat.py` (3 UT — MCP tool signature + guardrail), `tests/test_fts5_index.py` (3 UT — fallback dispatch, busy_timeout, NotReady message). Fase 3 of the FTS5 Lexical Fast-Path plan.

--- a/bench/test_bench_fts5_lexical.py
+++ b/bench/test_bench_fts5_lexical.py
@@ -1,0 +1,96 @@
+"""FTS5 lexical fast-path microbenchmarks (Fase 5, ADR-004 gate).
+
+Tracked metrics for the v4.9.0 default-flip gate:
+    bench_fts5_lexical_cold_p95           BENCH-001 target p95 <= 10ms
+    bench_fts5_lexical_hot_p95            BENCH-002 target p95 <=  2ms
+
+Regression sentinels (compared against the pre-Fase-5 baseline of
+``bench/test_bench_search.py`` via ``scripts/check_perf_regression.py
+--threshold 0.02``):
+    BENCH-003 — hybrid path with feature ON (<= 2% regression, gate G2)
+    BENCH-004 — hybrid path with feature OFF (zero-cost early-return)
+
+BENCH-003 and BENCH-004 are executed by re-running the existing
+``bench/test_bench_search.py`` suite with the FTS5 feature toggled via
+env override (see ``bench_v4_9_0_gate.md`` for the CI procedure). They
+are documented here — not duplicated — so the baseline metric IDs stay
+stable between comparisons.
+
+The ``corpus_3865_docs`` fixture from PRD ``_tests.md`` was not shipped
+as a shared fixture in earlier fases; this file builds an equivalent
+3865-row corpus in-process against a temporary SQLite FTS5 index. That
+keeps the bench self-contained and lets CI cells run it without a
+FastEmbed/ChromaDB download.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.fts5_index import Fts5LexicalIndex
+
+_CORPUS_SIZE = 3865
+_LEXICAL_QUERIES = ["CVE-2021-4034", "MDR-AD002", "T1078.001", "CWE-79"]
+
+
+def _seed_fts5_corpus(index: Fts5LexicalIndex) -> None:
+    """Populate ``index`` with 3865 synthetic docs carrying identifier tokens.
+
+    Every 100th chunk carries one of the four lexical query identifiers so
+    each benchmark query hits ~10 rows — enough to exercise the FTS5 bm25()
+    ranker without dominating latency with row-materialisation cost.
+    """
+    for i in range(_CORPUS_SIZE):
+        marker = _LEXICAL_QUERIES[i % len(_LEXICAL_QUERIES)] if i % 100 == 0 else ""
+        content = f"document {i} kerberoast bloodhound impacket privilege escalation lateral movement notes on {marker}"
+        index.add_document(
+            chunk_id=f"chunk-{i}",
+            content=content,
+            filename=f"doc-{i}.md",
+            category="benchmarks",
+        )
+
+
+@pytest.fixture(scope="module")
+def fts5_index(tmp_path_factory):
+    """Fresh FTS5 index seeded with 3865 rows, closed on teardown."""
+    tmp = tmp_path_factory.mktemp("fts5_bench")
+    idx = Fts5LexicalIndex(
+        db_path=tmp / "fts5_index.db",
+        state_path=tmp / "fts5_migration.state",
+    )
+    _seed_fts5_corpus(idx)
+    yield idx
+    idx.close()
+
+
+@pytest.mark.parametrize("query", _LEXICAL_QUERIES)
+def test_bench_fts5_lexical_cold(benchmark, fts5_index, query):
+    """BENCH-001 — cold FTS5 lookup on a 3865-doc corpus (rerank OFF default).
+
+    Target: p95 <= 10ms per ADR-004 gate G1 (measured post-run by
+    ``scripts/check_perf_regression.py`` against the hybrid baseline).
+    """
+
+    def run():
+        return fts5_index.search(query, top_k=10)
+
+    result = benchmark(run)
+    assert isinstance(result, list)
+
+
+@pytest.mark.parametrize("query", _LEXICAL_QUERIES)
+def test_bench_fts5_lexical_hot(benchmark, fts5_index, query):
+    """BENCH-002 — hot FTS5 lookup (SQLite page-cache warmed by BENCH-001).
+
+    Target: p95 <= 2ms. Ordering matters — this test relies on the
+    ``fts5_index`` module-scoped fixture having been queried already by
+    BENCH-001, so pytest's default file-order collection preserves the
+    warm-cache semantics.
+    """
+
+    def run():
+        return fts5_index.search(query, top_k=10)
+
+    result = benchmark(run)
+    assert isinstance(result, list)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -258,37 +258,38 @@ search:
   collection_name: "knowledge_base"
 
   # -----------------------------------------------------------------------
-  # FTS5 Lexical Fast-Path (v4.8.2+, opt-in)
+  # FTS5 Lexical Fast-Path (v4.8.2+, opt-in — default OFF pending v4.9.0)
   # -----------------------------------------------------------------------
   # Dedicated SQLite FTS5 index (data/fts5_index.db) optimized for exact
   # identifier queries (CVE-IDs, MITRE ATT&CK codes, VRT/CWE codes, file
   # hashes, error strings). See ADR-001 (storage), ADR-005 (tokenizer),
-  # ADR-004 (v4.9.0 default flip gated on bench).
+  # ADR-004 (v4.9.0 default flip gated on bench), ADR-009 (gate deferred
+  # to CI perf-gate). Full user guide: docs/features/fts5_fast_path.md.
   #
-  # Fase 1 ships the module only — Task 03 wires dispatch. Enabling now has
-  # no runtime effect until Task 03 lands. Uncomment to opt in later.
-  #
-  # lexical_fast_path:
-  #   # Master toggle. Default false preserves v4.8.1 behavior byte-for-byte.
-  #   enabled: false
-  #
-  #   # Minimum FTS5 hits required to skip the hybrid fallback. Queries
-  #   # returning fewer than this many results fall back to hybrid so recall
-  #   # is not sacrificed for a nearly-empty lexical result set.
-  #   min_hits: 3
-  #
-  #   # Run the cross-encoder reranker on FTS5 results. Default false (ADR-003)
-  #   # because identifier queries rank correctly on bm25() alone and the
-  #   # reranker adds ~40-80ms per query without measurable recall gain.
-  #   rerank_enabled: false
-  #
-  #   # First-match-wins regex patterns that classify a query as "lexical".
-  #   # Ordering matters (PRD OQ-2). Default set targets bug bounty + SOC/DFIR
-  #   # identifier vocabulary. Add custom project-specific codes below.
-  #   patterns:
-  #     - "[A-Z]{2,}-\\d+"        # H1-P4-XXX, MDR-AD002, CWE-79, MS17-010
-  #     - "CVE-\\d{4}-\\d+"       # canonical CVE identifiers
-  #     - "^[a-f0-9]{32,64}$"     # md5/sha1/sha256 file hashes
+  # The default remains `enabled: false` for v4.8.x. Setting `enabled: true`
+  # here opts your instance in early — see the docs page for latency
+  # expectations, migration behaviour, and telemetry counters.
+  lexical_fast_path:
+    # Master toggle. Default false preserves v4.8.1 behavior byte-for-byte.
+    enabled: false
+
+    # Minimum FTS5 hits required to skip the hybrid fallback. Queries
+    # returning fewer than this many results fall back to hybrid so recall
+    # is not sacrificed for a nearly-empty lexical result set.
+    min_hits: 3
+
+    # Run the cross-encoder reranker on FTS5 results. Default false (ADR-003)
+    # because identifier queries rank correctly on bm25() alone and the
+    # reranker adds ~40-80ms per query without measurable recall gain.
+    rerank_enabled: false
+
+    # First-match-wins regex patterns that classify a query as "lexical".
+    # Ordering matters (PRD OQ-2). Default set targets bug bounty + SOC/DFIR
+    # identifier vocabulary. Add custom project-specific codes below.
+    patterns:
+      - "[A-Z]{2,}-\\d+"        # H1-P4-XXX, MDR-AD002, CWE-79, MS17-010
+      - "CVE-\\d{4}-\\d+"       # canonical CVE identifiers
+      - "^[a-f0-9]{32,64}$"     # md5/sha1/sha256 file hashes
 
 
 # ============================================================================

--- a/docs/features/fts5_fast_path.md
+++ b/docs/features/fts5_fast_path.md
@@ -1,0 +1,161 @@
+# FTS5 Lexical Fast-Path
+
+**Status:** Opt-in in v4.8.2. Default flip to `enabled: true` is gated on the
+CI perf-gate procedure documented in ADR-009 and reserved for v4.9.0.
+
+## Overview
+
+The lexical fast-path is a dedicated SQLite FTS5 index optimised for exact
+identifier queries — CVE IDs, MITRE ATT&CK codes, VRT/CWE codes, file hashes,
+bug-bounty report IDs, error strings. When a query looks lexical, the
+`KnowledgeOrchestrator` dispatches to the FTS5 index and skips the full
+hybrid pipeline (BM25 + semantic + RRF + reranker), returning results in
+under ~10ms cold / ~2ms hot on a 3865-doc corpus.
+
+Non-lexical queries continue to flow through the existing hybrid pipeline
+byte-for-byte — the fast-path only intercepts what its regex router
+classifies as lexical.
+
+## Quick Start
+
+1. Add the block to your `config.yaml`:
+
+```yaml
+search:
+  lexical_fast_path:
+    enabled: true
+```
+
+2. Restart the server. On first start with the flag on, a background
+   daemon thread rebuilds the FTS5 index from your existing ChromaDB
+   corpus. Progress is checkpointed every 100 rows to
+   `data/fts5_migration.state`; queries during migration transparently
+   fall back to the hybrid pipeline.
+
+3. Check readiness:
+
+```bash
+curl -s http://127.0.0.1:9179/metrics | grep knowledge_rag_fast_path
+```
+
+`knowledge_rag_fast_path_migration_docs_indexed` reaching
+`_docs_total` marks the fast-path as live.
+
+## Configuration Reference
+
+Full field docs live in `config.example.yaml` under
+`search.lexical_fast_path`. The five knobs:
+
+| Field            | Default | What it controls                                              |
+| ---------------- | ------- | ------------------------------------------------------------- |
+| `enabled`        | `false` | Master toggle. Off → zero runtime cost, no FTS5 index open.   |
+| `min_hits`       | `3`     | Minimum FTS5 hits to skip hybrid fallback (recall safety).    |
+| `rerank_enabled` | `false` | Layer cross-encoder rerank on FTS5 hits. ADR-003 keeps off.   |
+| `patterns`       | *(see)* | First-match-wins regex list that classifies "lexical".        |
+
+Default `patterns`:
+
+```yaml
+patterns:
+  - "[A-Z]{2,}-\\d+"    # H1-P4-XXX, MDR-AD002, CWE-79, MS17-010
+  - "CVE-\\d{4}-\\d+"   # canonical CVE identifiers
+  - "^[a-f0-9]{32,64}$" # md5/sha1/sha256 file hashes
+```
+
+Add project-specific taxonomies at the end of the list — ordering matters
+(PRD OQ-2), first match wins.
+
+## How It Works
+
+Query flow when the fast-path is enabled:
+
+1. `QueryRouter.classify(query)` runs the regex list. Returns `"lexical"` on
+   first hit, else `"semantic"` (empty query defaults to `"semantic"`).
+2. `"semantic"` → hybrid pipeline unchanged.
+3. `"lexical"` → `Fts5LexicalIndex.search(query, top_k)` (SQLite FTS5 `MATCH`
+   + `bm25()` ordering). Returns `[(chunk_id, score)]`.
+4. If result count `< min_hits` → fall back to hybrid, increment
+   `knowledge_rag_fast_path_fallback_total{reason="low_hits"}`.
+5. Else → optional rerank pass (only if `rerank_enabled: true`), then
+   adjacent-chunk expansion identical to the hybrid path.
+
+The `search_knowledge` MCP tool exposes an override:
+`search_method: Literal["auto", "hybrid", "fts5"] = "auto"`.
+
+- `"auto"` (default) — router decides.
+- `"hybrid"` — force full hybrid pipeline, ignore router.
+- `"fts5"` — force fast-path even for prosa queries. When the index is not
+  ready, returns a structured JSON error envelope with a `suggestion` field
+  pointing back at `"auto"`.
+
+See ADR-006 for the API surface diff (LEI 1 compatible — additive tail
+kwarg, all existing calls unchanged).
+
+## Troubleshooting
+
+**1. All queries fall back to hybrid, fast-path never fires.**
+Check `knowledge_rag_fast_path_fallback_total{reason="disabled"}`. Non-zero
+means `enabled: false` — verify the config path and restart. If
+`{reason="migration_pending"}` is climbing, the background rebuild is still
+running; see `_migration_docs_indexed / _docs_total` gauges for progress.
+
+**2. Lexical query returns `NO_RESULTS` but hybrid finds the chunk.**
+Router probably misclassified. Confirm with an explicit
+`search_method="fts5"` call — if that returns hits, the pattern list is
+right and `min_hits` may be too aggressive; lower to `1`. If the forced
+`"fts5"` call also empty, the FTS5 index does not contain that chunk — run
+`python scripts/build_fts5_index.py --data-dir <path> --force` to rebuild
+from ChromaDB.
+
+**3. Latency higher than the 10ms budget.**
+Check `knowledge_rag_fast_path_latency_seconds_bucket`. Latency above the
+`le="0.010"` bucket generally means `rerank_enabled: true` — the
+cross-encoder adds 40-80ms per query (ADR-003). Set `rerank_enabled:
+false` and re-measure.
+
+**4. `Fts5NotReadyError` in logs after restart.**
+Index migration failed. Inspect `data/fts5_migration.state` (JSON marker
+file). `state: "failed"` includes the exception. Remedy: run the standalone
+rebuild helper:
+
+```bash
+python scripts/build_fts5_index.py --data-dir ./data --force --foreground
+```
+
+**5. Storage doubled after enabling.**
+Expected during migration — the FTS5 index is a full copy of the corpus in
+a dedicated SQLite database. After migration completes, expect
+`fts5_index.db` to sit at roughly 30-60% of ChromaDB's on-disk size on a
+typical mixed corpus.
+
+## When to Use vs. Not
+
+**Enable when:**
+- Your corpus is dominated by exact identifiers (CVEs, CWEs, MITRE codes,
+  hashes, bug-bounty report IDs, error codes).
+- You measure hybrid-path latency and see the semantic branch adding
+  cost you do not need for identifier lookups.
+- You want deterministic ranking on identifier queries — BM25 alone is
+  reproducible; RRF + semantic can drift as embedding models change.
+
+**Leave off when:**
+- Your corpus is prose-heavy and identifier queries are rare (< 5% of
+  traffic).
+- You depend on the cross-encoder reranker for lexical queries too
+  (recall over latency) — the fast-path skips rerank by default.
+- You cannot afford the one-time migration cost (5-30 minutes on 3865
+  docs, longer on larger corpora).
+
+## References
+
+- ADR-001 — storage layout (`data/fts5_index.db`, PRAGMAs)
+- ADR-002 — regex router (first-match-wins, unanchored)
+- ADR-003 — rerank OFF default (empirical basis)
+- ADR-004 — v4.9.0 default-flip conditional gate
+- ADR-005 — tokenizer (`unicode61 remove_diacritics 2 tokenchars '-_.'`)
+- ADR-006 — `search_method` MCP tool surface diff
+- ADR-008 — CRUD sync + lazy migration (Fase 4)
+- ADR-009 — bench gate deferred to CI
+- `docs/runbooks/fts5_migration.md` — operator runbook
+- `.compozy/tasks/fts5-lexical-fast-path/bench_v4_9_0_gate.md` — gate
+  procedure and result template

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -8,7 +8,7 @@ import sys  # noqa: I001
 _original_stdout = sys.stdout
 sys.stdout = sys.stderr
 
-__version__ = "4.8.1"
+__version__ = "4.8.2"
 __author__ = "Ailton Rocha (Lyon.)"
 
 from .config import Config  # noqa: E402

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-rag",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "Local RAG System for Claude Code \u00e2\u20ac\u201d Hybrid search + Cross-encoder Reranking + 13 MCP Tools + 20 Format Parsers. Zero external servers.",
   "bin": {
     "knowledge-rag": "./bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "knowledge-rag"
-version = "4.8.1"
+version = "4.8.2"
 description = "Local RAG System for Claude Code — Hybrid search + Cross-encoder Reranking + 13 MCP Tools + 20 Format Parsers. Zero external servers."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

**v4.8.2 - FTS5 Lexical Fast-Path opt-in release (default OFF, LEI 1 preserved).**

Bundles Fases 1-5 of the FTS5 Lexical Fast-Path plan as a conservative patch release. `search.lexical_fast_path.enabled` remains `false` by default - users who do not touch `config.yaml` keep v4.8.1 behaviour byte-for-byte.

## What ships

- Version bump 4.8.1 -> 4.8.2 (3 files atomic: `pyproject.toml` + `mcp_server/__init__.py` + `npm/package.json`)
- Bench harness `bench/test_bench_fts5_lexical.py` - BENCH-001 cold (p95 <=10ms target) + BENCH-002 hot (p95 <=2ms target) against 3865-row FTS5 corpus
- User guide `docs/features/fts5_fast_path.md` (6.5K) - overview, quick-start, config reference, troubleshooting, when-to-use
- README `## Configuration` section: new `### Search Method (v4.8.2+)` subsection with 3-method comparison table
- CHANGELOG entry `## v4.8.2` with LEI 1 + ADR-004 + ADR-009 references

## Path C - Deferred gate (ADR-009 emergent decision)

The ADR-004 v4.9.0 gate (G1 >=15x lexical / G2 <=2% hybrid regression) was **not** adjudicated locally because the release-authoring workstation cannot fairly baseline against CI hardware (see ADR-004 Risks). The gate is deferred to the CI perf-gate adjudication documented in ADR-009. The v4.9.0 default flip PR follows once G1 + G2 both pass on CI hardware.

## What does NOT ship

- No default flip - `enabled: false` preserves v4.8.1 behavior
- No new MCP tool - `search_knowledge` signature added `search_method` in v4.8.2 (PR #160), unchanged here

## LEI 1 preserved

Zero change to the 13 frozen MCP tools. Default OFF preserves v4.8.1 byte-for-byte.

## Rollback

`git revert <sha>` - feature is opt-in default-off; revert is safe. Standalone `scripts/build_fts5_index.py` (from PR #167) continues to work for manual FTS5 rebuild.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in FTS5 lexical fast path for faster identifier-focused searches.
  * Added `auto`, `hybrid`, and `fts5` search method options.
  * Added configuration controls for lexical matching, reranking, and query classification.

* **Documentation**
  * Added setup, migration, troubleshooting, usage, and performance guidance.

* **Tests**
  * Added benchmarks covering cold and warmed lexical search performance.

* **Chores**
  * Updated the release version to 4.8.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR releases version 4.8.2 and documents the opt-in FTS5 lexical fast path while adding its performance harness. The version and default-off example configuration are consistent, but the benchmark does not produce a valid cold measurement and the advertised hybrid regression gate is not executable as shipped.

- Bumps Python, server, and npm package versions to 4.8.2.
- Publishes the fast-path user guide, README release notes, and enabled-by-example configuration block with the feature still off by default.
- Adds parametrized cold and hot FTS5 microbenchmarks over a synthetic 3,865-row corpus.

<h3>Confidence Score: 3/5</h3>

The release should not merge until the cold benchmark isolates cache state and the advertised feature-on hybrid regression gate is made executable.

The new harness measures warmed SQLite searches as cold and does not implement the enabled-versus-disabled hybrid comparison required to adjudicate the future default flip.

**Files Needing Attention:** bench/test_bench_fts5_lexical.py, docs/features/fts5_fast_path.md, README.md

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| bench/test_bench_fts5_lexical.py | Adds the FTS5 latency harness, but shared cache state invalidates BENCH-001 and the documented BENCH-003/004 procedure has no executable implementation. |
| docs/features/fts5_fast_path.md | Provides a comprehensive opt-in guide, with a minor incorrect count of supported configuration fields. |
| config.example.yaml | Exposes the four supported fast-path settings while correctly preserving enabled=false. |
| README.md | Documents the release and deferred gate, but repeats the unsupported claim that CI executes the hybrid regression comparison. |
| mcp_server/__init__.py | Correctly bumps the server version to 4.8.2. |
| npm/package.json | Correctly bumps the npm package version to 4.8.2. |
| pyproject.toml | Correctly bumps the Python package version to 4.8.2. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Abench%2Ftest_bench_fts5_lexical.py%3A54-64%0A**Cold%20benchmark%20reuses%20warm%20cache**%0A%0AWhen%20CI%20runs%20the%20parametrized%20cold%20benchmark%2C%20calibration%20and%20measurement%20calls%20reuse%20the%20same%20module-scoped%20SQLite%20connection%2C%20warming%20its%20page%20cache%20before%20recorded%20samples%20and%20causing%20BENCH-001%20to%20report%20warm%20or%20partially%20warm%20latency%20instead%20of%20the%20required%20cold%20latency.%0A%0A%23%23%23%20Issue%202%0Abench%2Ftest_bench_fts5_lexical.py%3A13-17%0A**Hybrid%20regression%20gate%20is%20absent**%0A%0AWhen%20CI%20adjudicates%20G2%2C%20it%20runs%20the%20ordinary%20branch%20and%20master%20benchmark%20suites%20without%20the%20documented%20FTS5%20environment%20toggle%2C%20while%20%60test_bench_search.py%60%20does%20not%20exercise%20orchestrator%20fast-path%20dispatch.%20The%20resulting%20comparison%20cannot%20detect%20a%20hybrid%20regression%20caused%20by%20enabling%20FTS5.%0A%0A%23%23%23%20Issue%203%0Adocs%2Ffeatures%2Ffts5_fast_path.md%3A47%0A**Configuration%20knob%20count%20is%20incorrect**%0A%0AThe%20guide%20says%20there%20are%20five%20knobs%2C%20but%20the%20following%20table%20and%20runtime%20schema%20define%20only%20four%2C%20leaving%20users%20searching%20for%20a%20nonexistent%20setting%20or%20wondering%20whether%20the%20reference%20is%20incomplete.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=lyonzin%2Fknowledge-rag&pr=168&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
bench/test_bench_fts5_lexical.py:54-64
**Cold benchmark reuses warm cache**

When CI runs the parametrized cold benchmark, calibration and measurement calls reuse the same module-scoped SQLite connection, warming its page cache before recorded samples and causing BENCH-001 to report warm or partially warm latency instead of the required cold latency.

### Issue 2
bench/test_bench_fts5_lexical.py:13-17
**Hybrid regression gate is absent**

When CI adjudicates G2, it runs the ordinary branch and master benchmark suites without the documented FTS5 environment toggle, while `test_bench_search.py` does not exercise orchestrator fast-path dispatch. The resulting comparison cannot detect a hybrid regression caused by enabling FTS5.

### Issue 3
docs/features/fts5_fast_path.md:47
**Configuration knob count is incorrect**

The guide says there are five knobs, but the following table and runtime schema define only four, leaving users searching for a nonexistent setting or wondering whether the reference is incomplete.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["release: v4.8.2 - FTS5 Lexical Fast-Path..."](https://github.com/lyonzin/knowledge-rag/commit/294b1d4427efad1e8848dff857bce0bd0d85f7f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51980130)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->