### PR TITLE
docs(architecture): sync mermaid diagrams with v4.8.2 fast-path + v4.8.3 staging dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,19 +230,32 @@ See [Changelog](#changelog) for full history.
 flowchart TB
     subgraph MCP["MCP SERVER (FastMCP)"]
         direction TB
-        TOOLS["13 MCP Tools<br/>search | get | add | update | remove<br/>reindex | reindex_status | list | stats | url | similar | evaluate"]
+        TOOLS["13 MCP Tools (frozen, LEI 1)<br/>search_knowledge | get_document | search_similar<br/>add_document | add_from_url | update_document | remove_document<br/>reindex_documents | get_reindex_status<br/>list_categories | list_documents | get_index_stats | evaluate_retrieval"]
     end
 
-    subgraph SEARCH["HYBRID SEARCH ENGINE"]
+    subgraph SEARCH["SEARCH DISPATCH (v4.8.2+)"]
+        direction TB
+        SM["search_method dispatch<br/>auto | hybrid | fts5"]
+        QROUTER["QueryRouter (regex)<br/>lexical vs semantic<br/>(ADR-002)"]
+        FTS5PATH["FTS5 Fast-Path<br/>(exact identifiers <10ms)"]
+        HYBRIDPATH["Hybrid Pipeline<br/>(conceptual queries)"]
+
+        SM --> QROUTER
+        QROUTER -->|lexical| FTS5PATH
+        QROUTER -->|semantic| HYBRIDPATH
+        FTS5PATH -.->|not_ready / low_hits<br/>fallback| HYBRIDPATH
+    end
+
+    subgraph HYBRID["HYBRID PIPELINE"]
         direction LR
-        ROUTER["Keyword Router<br/>(word boundaries)"]
+        KWROUTER["Keyword Router<br/>(word boundaries → category filter)"]
         SEMANTIC["Semantic Search<br/>(ChromaDB)"]
         BM25["BM25 Keyword<br/>(inverted-index + expansion)"]
         RRF["Reciprocal Rank<br/>Fusion (RRF)"]
         RERANK["Cross-Encoder<br/>Reranker"]
 
-        ROUTER --> SEMANTIC
-        ROUTER --> BM25
+        KWROUTER --> SEMANTIC
+        KWROUTER --> BM25
         SEMANTIC --> RRF
         BM25 --> RRF
         RRF --> RERANK
@@ -250,9 +263,11 @@ flowchart TB
 
     subgraph STORAGE["STORAGE LAYER"]
         direction LR
-        CHROMA[("ChromaDB<br/>Vector Database")]
-        COLLECTIONS["Collections<br/>security | ctf<br/>logscale | development"]
+        CHROMA[("ChromaDB<br/>data/chroma_db/<br/>(vector store)")]
+        FTS5DB[("SQLite FTS5<br/>data/fts5_index.db<br/>(lexical index, ADR-001)")]
+        COLLECTIONS["8 Categories<br/>redteam | blueteam | ctf<br/>security | logscale<br/>development | aar | general"]
         CHROMA --- COLLECTIONS
+        FTS5DB --- COLLECTIONS
     end
 
     subgraph EMBED["EMBEDDINGS (In-Process)"]
@@ -264,36 +279,55 @@ flowchart TB
     subgraph INGEST["DOCUMENT INGESTION"]
         PARSERS["20 Parsers<br/>MD | PDF | TXT | PY | C | H | CPP | JS | JSX | TS | TSX | JSON | XML | CSV<br/>DOCX | XLSX | PPTX | IPYNB | MQH | MQ4"]
         CHUNKER["Chunking<br/>MD: section-aware<br/>Other: 1000 chars + 200 overlap"]
-        PARSERS --> CHUNKER
+        FTS5SYNC["FTS5 CRUD sync<br/>(v4.8.2 task 05)"]
+        PARSERS --> CHUNKER --> FTS5SYNC
     end
 
     CLAUDE["Claude Code"] --> MCP
     MCP --> SEARCH
-    SEARCH --> STORAGE
+    HYBRIDPATH --> HYBRID
+    FTS5PATH --> FTS5DB
+    HYBRID --> STORAGE
     STORAGE --> EMBED
     INGEST --> EMBED
     EMBED --> STORAGE
+    FTS5SYNC --> FTS5DB
 ```
 
 ### Query Processing Flow
 
 ```mermaid
 flowchart TB
-    QUERY["User Query<br/>'mimikatz credential dump'"] --> EXPAND
+    QUERY["User Query<br/>'mimikatz credential dump' | 'CVE-2021-4034'"] --> METHOD
 
-    subgraph EXPANSION["Query Expansion"]
+    subgraph DISPATCH["Dispatch (v4.8.2+, ADR-006)"]
+        METHOD{"search_method<br/>auto | hybrid | fts5"}
+        AUTOROUTE["QueryRouter.classify()<br/>regex-based lexical detection"]
+        FASTPATH["FTS5 Fast-Path<br/>SQLite MATCH<br/>(&lt;10ms cold, &lt;2ms hot)"]
+        NOTREADY{"FTS5 ready<br/>AND hits >= min_hits?"}
+
+        METHOD -->|auto| AUTOROUTE
+        METHOD -->|fts5| FASTPATH
+        METHOD -->|hybrid| EXPAND
+        AUTOROUTE -->|lexical| FASTPATH
+        AUTOROUTE -->|semantic| EXPAND
+        FASTPATH --> NOTREADY
+        NOTREADY -->|no, fallback| EXPAND
+    end
+
+    subgraph EXPANSION["Query Expansion (hybrid path)"]
         EXPAND["Synonym Expansion<br/>mimikatz -> mimikatz, sekurlsa, logonpasswords"]
     end
 
-    EXPAND --> ROUTER
+    EXPAND --> KWROUTER
 
-    subgraph ROUTING["Keyword Routing"]
-        ROUTER["Keyword Router"]
+    subgraph ROUTING["Keyword Routing (category filter)"]
+        KWROUTER["Keyword Router<br/>(word boundaries)"]
         MATCH{"Word Boundary<br/>Match?"}
         CATEGORY["Filter: redteam"]
         NOFILTER["No Filter"]
 
-        ROUTER --> MATCH
+        KWROUTER --> MATCH
         MATCH -->|Yes| CATEGORY
         MATCH -->|No| NOFILTER
     end
@@ -326,7 +360,8 @@ flowchart TB
     BM25 --> RRF
 
     ADJ --> MINSCORE
-    SNIPPET --> RESULTS["Results<br/>search_method: hybrid|semantic|keyword<br/>score + filtered_by_score + content_length"]
+    NOTREADY -->|yes, hit| MINSCORE
+    SNIPPET --> RESULTS["Results<br/>search_method: fts5 | hybrid | semantic | keyword<br/>routed_by: fts5_router | none<br/>score + filtered_by_score + content_length"]
 ```
 
 ### Document Ingestion Flow
@@ -334,7 +369,7 @@ flowchart TB
 ```mermaid
 flowchart LR
     subgraph INPUT["Input"]
-        FILES["documents/<br/>├── security/<br/>├── development/<br/>├── ctf/<br/>└── general/"]
+        FILES["documents/<br/>├── security/<br/>│   ├── redteam/<br/>│   ├── blueteam/<br/>│   └── ctf/<br/>├── aar/<br/>├── logscale/<br/>├── development/<br/>└── general/"]
     end
 
     subgraph PARSE["Parse (20 formats)"]
@@ -354,9 +389,18 @@ flowchart LR
         FASTEMBED["FastEmbed ONNX<br/>bge-small-en-v1.5<br/>(384D, CPU or GPU)"]
     end
 
+    subgraph DISPATCH["Write Dispatch (v4.8.3, #161)"]
+        WCOL{"_write_collection<br/>routes writes"}
+        STAGING["Staging Collection<br/>(nuclear_rebuild only,<br/>keeps prod serving queries)"]
+        PROD["Production Collection<br/>(default)"]
+        WCOL -->|_staging_target set| STAGING
+        WCOL -->|default| PROD
+    end
+
     subgraph STORE["Store"]
-        CHROMADB[("ChromaDB")]
-        BM25IDX["BM25 Index"]
+        CHROMADB[("ChromaDB<br/>data/chroma_db/")]
+        BM25IDX["BM25 Index<br/>(in-memory,<br/>rebuilt on write)"]
+        FTS5DB[("SQLite FTS5<br/>data/fts5_index.db<br/>(CRUD-synced, ADR-008)")]
     end
 
     FILES --> MD & PDF & OFFICE & CODE
@@ -365,14 +409,20 @@ flowchart LR
     MDSPLIT --> DEDUP
     TXTSPLIT --> DEDUP
     DEDUP --> EMBED
-    EMBED --> STORE
+    EMBED --> DISPATCH
+    STAGING --> CHROMADB
+    PROD --> CHROMADB
+    PROD --> BM25IDX
+    PROD --> FTS5DB
 ```
 
 ### hybrid_alpha Parameter Effect
 
+`hybrid_alpha` weights RRF fusion between semantic and BM25 rankings on the **hybrid pipeline only**. When `search_method="auto"` and the QueryRouter classifies the query as lexical (e.g. `CVE-2021-4034`, `MDR-AD002`, `T1078.001`, file hashes), the FTS5 fast-path fires and `hybrid_alpha` is not consulted — FTS5 uses SQLite's native `bm25()` scoring exclusively. Pass `search_method="hybrid"` to force RRF fusion + rerank on every query if you want deterministic hybrid semantics regardless of the query shape.
+
 ```mermaid
 flowchart LR
-    subgraph ALPHA["hybrid_alpha values"]
+    subgraph ALPHA["hybrid_alpha values (hybrid path only)"]
         A0["0.0<br/>Pure BM25<br/>Instant"]
         A3["0.3 (default)<br/>Keyword-heavy<br/>Fast"]
         A5["0.5<br/>Balanced"]
@@ -381,7 +431,7 @@ flowchart LR
     end
 
     subgraph USE["Best For"]
-        U0["CVEs, tool names<br/>exact matches"]
+        U0["CVEs, tool names<br/>exact matches<br/>(consider FTS5 fast-path)"]
         U3["Technical queries<br/>specific terms"]
         U5["General queries"]
         U7["Conceptual queries<br/>related topics"]
@@ -1434,6 +1484,8 @@ Common issues:
 ## Changelog
 
 ### Unreleased
+
+- **docs(architecture)**: sync the 4 Mermaid diagrams in `## Architecture` (System Overview, Query Processing Flow, Document Ingestion Flow, hybrid_alpha Parameter Effect) with the v4.8.2 FTS5 fast-path (ADR-002/003/006), the v4.8.3 `_write_collection` staging dispatcher (#161), and the current 8-category layout. The diagrams previously described only the pre-v4.8 hybrid pipeline and 4-category storage; they now also show FTS5 dispatch, fallback semantics, FTS5 CRUD sync (ADR-008), and the zero-downtime staging write path. `hybrid_alpha` now clarifies that the fast-path bypasses RRF entirely so the weighting only matters on the hybrid path.
 
 ### v4.8.3 (2026-08-10) — Critical hotfix: nuclear-rebuild + smart-reindex hardening
 


### PR DESCRIPTION
## Summary

Syncs the 4 Mermaid diagrams in `## Architecture` (System Overview, Query Processing Flow, Document Ingestion Flow, hybrid_alpha Parameter Effect) with what the code actually does in v4.8.2 (FTS5 Lexical Fast-Path) and v4.8.3 (`_write_collection` staging dispatcher, `#161`). The previous diagrams still described the pre-v4.8 hybrid-only pipeline and a 4-category storage layout, so any user reading the README would miss the FTS5 fast-path, the `search_method` dispatch, the FTS5 storage box, the FTS5 CRUD sync in ingestion, and the zero-downtime staging write path.

Docs-only. No code change, no test change, no version bump.

## What changed

- **System Overview**: adds SEARCH DISPATCH subgraph (`search_method: auto | hybrid | fts5`, ADR-006), `QueryRouter` lexical detection (ADR-002), FTS5 fast-path branch with fallback edge to the hybrid pipeline, SQLite FTS5 storage box (`data/fts5_index.db`, ADR-001), the FTS5 CRUD sync step in ingestion, the full 8 categories (redteam | blueteam | ctf | security | logscale | development | aar | general — was showing only 4), and marks the 13 MCP tools as frozen (LEI 1) with the actual names.
- **Query Processing Flow**: new DISPATCH block at the top of the flow — `search_method` decision, `QueryRouter.classify()` auto-routing, FTS5 fast-path with `ready AND hits >= min_hits` gate, and the fallback edge back to expansion + hybrid path. Result envelope updated to show `search_method: fts5` and `routed_by: fts5_router`.
- **Document Ingestion Flow**: expanded input tree to the 8-category layout, added Write Dispatch subgraph (v4.8.3 `#161`) showing `_write_collection` routing writes to staging during `nuclear_rebuild` and to production otherwise, and added SQLite FTS5 as a third store sink (ADR-008 CRUD sync).
- **hybrid_alpha Parameter Effect**: added explanatory paragraph that `hybrid_alpha` only affects the hybrid path — the FTS5 fast-path uses SQLite `bm25()` natively and ignores the weight. Subgraph title clarified, `0.0 (Pure BM25)` label points readers to the fast-path as an alternative for exact identifier queries.

## LEI 1 preserved

Docs-only. Zero change to the 13 frozen MCP tools, zero change to API surface, zero change to test count.

## Test plan

- [x] All 4 Mermaid blocks still render (verified 4 `flowchart` opens in file)
- [x] CHANGELOG entry in `### Unreleased`
- [x] No version bump (docs-only)
- [ ] 7 pillar Quality Gate green (skip-test-count + skip-changelog labels not needed — CHANGELOG entry included, no test change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated architecture documentation for FTS5 lexical search, query routing, fallback behavior, and CRUD synchronization.
  - Clarified search result fields, category support, scoring behavior, and `hybrid_alpha` usage.
  - Documented staging and production write routing for zero-downtime ingestion.
  - Added an Unreleased changelog entry summarizing these updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the README architecture documentation for FTS5 query dispatch, staging-aware ingestion, the eight-category layout, and hybrid weighting behavior.
- Adds auto, hybrid, and forced-FTS5 query branches with fallback and result metadata.
- Documents staging collection routing and the ChromaDB, BM25, and FTS5 stores.
- Expands the tool and category descriptions and adds an Unreleased changelog entry.

<h3>Confidence Score: 4/5</h3>

The documentation-only PR is safe to merge, but two architecture paths should be corrected to avoid misleading users about forced FTS5 errors and rebuild-time index consistency.

Runtime behavior is unchanged; the remaining issues are inaccurate diagram branches for explicit FTS5 dispatch and BM25/FTS5 maintenance during rebuilds.

**Files Needing Attention:** README.md

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Updates four architecture diagrams and the changelog; the forced-FTS5 fallback semantics and rebuild-time secondary-index flows remain inaccurately represented. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Q[Query] --> D{search_method}
    D -->|auto| R[QueryRouter]
    D -->|hybrid| H[Hybrid pipeline]
    D -->|fts5| F[FTS5 fast path]
    R -->|semantic| H
    R -->|lexical| F
    F --> O[Output processing]
    H --> O
    I[Document ingestion] --> W{Write collection}
    W -->|default| P[Production ChromaDB]
    W -->|rebuild| S[Staging ChromaDB]
    P --> B[BM25 / FTS5 maintenance]
    S --> X[Post-swap index rebuild]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0AREADME.md%3A314-315%0A**Forced%20FTS5%20fallback%20is%20inaccurate**%0A%0AThe%20diagram%20sends%20explicit%20%60search_method%3D%22fts5%22%60%20requests%20through%20the%20auto-mode%20fallback%20gate.%20When%20FTS5%20is%20disabled%20or%20unready%2C%20forced%20mode%20returns%20%60Fts5NotReadyError%60%20instead%20of%20falling%20back%2C%20and%20forced%20searches%20also%20bypass%20%60min_hits%60%2C%20so%20readers%20receive%20behavior%20different%20from%20this%20documented%20flow.%0A%0A%23%23%23%20Issue%202%0AREADME.md%3A413-416%0A**Rebuild%20index%20flows%20are%20inaccurate**%0A%0AThese%20edges%20imply%20that%20only%20production%20writes%20update%20BM25%20and%20that%20FTS5%20is%20updated%20directly%20on%20every%20production%20write.%20Staging%20population%20also%20builds%20an%20isolated%20BM25%20index%2C%20while%20bulk%20and%20staging%20paths%20rebuild%20FTS5%20from%20ChromaDB%20only%20after%20the%20destructive%20rebuild%20or%20collection%20swap%2C%20giving%20operators%20the%20wrong%20consistency%20timeline%20during%20rebuilds.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=lyonzin%2Fknowledge-rag&pr=170&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:314-315
**Forced FTS5 fallback is inaccurate**

The diagram sends explicit `search_method="fts5"` requests through the auto-mode fallback gate. When FTS5 is disabled or unready, forced mode returns `Fts5NotReadyError` instead of falling back, and forced searches also bypass `min_hits`, so readers receive behavior different from this documented flow.

### Issue 2
README.md:413-416
**Rebuild index flows are inaccurate**

These edges imply that only production writes update BM25 and that FTS5 is updated directly on every production write. Staging population also builds an isolated BM25 index, while bulk and staging paths rebuild FTS5 from ChromaDB only after the destructive rebuild or collection swap, giving operators the wrong consistency timeline during rebuilds.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(architecture): sync mermaid diagram..."](https://github.com/lyonzin/knowledge-rag/commit/658e3e186240016c30e7c02d30594a8880c9f0c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52031942)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->