### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ flowchart LR
 
 ### hybrid_alpha Parameter Effect
 
-`hybrid_alpha` weights RRF fusion between semantic and BM25 rankings on the **hybrid pipeline only**. When `search_method="auto"` and the QueryRouter classifies the query as lexical (e.g. `CVE-2021-4034`, `MDR-AD002`, `T1078.001`, file hashes), the FTS5 fast-path fires and `hybrid_alpha` is not consulted — FTS5 uses SQLite's native `bm25()` scoring exclusively. Pass `search_method="hybrid"` to force RRF fusion + rerank on every query if you want deterministic hybrid semantics regardless of the query shape.
+`hybrid_alpha` weights RRF fusion between semantic and BM25 rankings on the **hybrid pipeline only**. When `search_method="auto"` and the QueryRouter classifies the query as lexical (e.g. `CVE-2021-4034`, `C2-CLOUDFLARE`, `T1078.001`, file hashes), the FTS5 fast-path fires and `hybrid_alpha` is not consulted — FTS5 uses SQLite's native `bm25()` scoring exclusively. Pass `search_method="hybrid"` to force RRF fusion + rerank on every query if you want deterministic hybrid semantics regardless of the query shape.
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
<!--
Thank you for contributing to knowledge-rag.

Every PR is evaluated against the 7 Pillars Quality Gate. Please fill every
section. Use [N/A] with a one-line justification if a section truly does not
apply.

See CONTRIBUTING.md for full details.
-->

## Summary

<!-- One paragraph: what changes and why. Link to the issue this fixes. -->

Closes #

## Type of change

- [ ] feat — new feature
- [ ] fix — bug fix
- [ ] docs — documentation only
- [ ] refactor — no behavior change
- [ ] perf — performance improvement
- [ ] test — adding or improving tests
- [ ] chore — tooling, deps, CI
- [ ] BREAKING CHANGE (explain in Migration section below)

## What changed

<!-- Bullet list of the actual changes. File paths welcome. -->

-
-

## Why

<!-- The motivation. What problem does this solve? Why this approach over alternatives? -->

---

## 7 Pillars Quality Gate

> Mark each item. CI enforces these via the `quality-gate.yml` workflow.

### 1. Security

- [ ] No new secrets, tokens, or credentials in the diff (gitleaks will block)
- [ ] No new use of `eval`, `exec`, `subprocess shell=True`, `pickle.loads` on untrusted input, or arbitrary deserialization
- [ ] New dependencies (if any) reviewed for known CVEs and license compatibility
- [ ] Path traversal, command injection, and SSRF surfaces explicitly considered for any new I/O code

### 2. Stability

- [ ] All existing tests still pass on Linux + Windows × Python 3.11/3.12
- [ ] New behavior covered by tests; tests are deterministic (no `time.sleep` / network / OS-scheduler dependencies)
- [ ] Coverage does not regress (codecov gate)
- [ ] No tests were skipped, deleted, or marked `xfail` to make the PR pass

### 3. Memory leak

- [ ] Long-lived objects (orchestrator, watcher, cache) are bounded
- [ ] New caches have eviction policy (LRU, TTL, or explicit size limit)
- [ ] No new global state that grows unbounded with usage
- [ ] If you added a new module that loads heavy resources, consider lazy initialization

### 4. Versatility

- [ ] Works on Linux, Windows, macOS (paths, line endings, locale considered)
- [ ] Works on Python 3.11, 3.12, 3.13 (no Python-version-specific syntax without fallback)
- [ ] No hardcoded paths, locales, or encodings (use `pathlib.Path`, `encoding="utf-8"` explicit)
- [ ] If you touched a parser, all 20 supported formats still parse correctly

### 5. Scalability

- [ ] No O(n²) or worse algorithms on user-controlled inputs
- [ ] Benchmark impact considered (run `pytest bench/` locally if you touched search/index/embed)
- [ ] If perf regression > 10% in any metric, justification provided below
- [ ] Concurrency safety: no new shared mutable state without lock or documented thread confinement

**Performance impact** (required if you touched `mcp_server/server.py`, `mcp_server/ingestion.py`, or `bench/`):

```
metric          before    after    delta
search p95      ___ ms    ___ ms   ___%
index docs/sec  ___       ___      ___%
RSS @ 1k docs   ___ MB    ___ MB   ___%
```

### 6. Versioning

- [ ] If this is user-facing change: bumped version in `pyproject.toml`, `mcp_server/__init__.py`, and `npm/package.json` atomically
- [ ] If this is a breaking change: bumped MAJOR, added migration notes in CHANGELOG, marked `BREAKING CHANGE:` in commit footer
- [ ] CHANGELOG updated with entry under `## Unreleased` in README.md
- [ ] Public API surface (`mcp_server/server.py` MCP tool decorators) unchanged, OR breaking changes documented

### 7. Quality

- [ ] `ruff check` passes
- [ ] `ruff format --check` passes
- [ ] Type hints on new public functions (`mypy --strict` clean for new files)
- [ ] Docstrings on new public functions (used by `interrogate`)
- [ ] Cyclomatic complexity reasonable (`radon cc --max=C`)
- [ ] No dead code (`vulture` would not flag new code)
- [ ] PR is reasonably sized (< 500 lines of diff preferred; bigger PRs split or justify)

---

## Migration / Breaking changes

<!-- Required if you marked BREAKING CHANGE. Otherwise write N/A. -->

N/A

## Test plan

<!-- How will the reviewer verify this works? What did you actually run? -->

- [ ] `pytest tests/ -v` passed locally
- [ ] `pre-commit run --all-files` clean
- [ ] Manual smoke test: <!-- describe what you did -->

## Documentation

- [ ] Updated `README.md` (if user-facing)
- [ ] Updated `docs/` (if applicable)
- [ ] Added entry to `## Unreleased` in README CHANGELOG section

## Reviewer checklist

<!-- Do not edit. The reviewer fills this. -->

- [ ] Reviewed line-by-line
- [ ] Verified the 7 pillars CI status checks are green
- [ ] Verified no obvious adversarial implications
- [ ] Approved performance impact

---

By submitting this PR I confirm I read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates one lexical-query example in the README's explanation of `hybrid_alpha`.

- Replaces `MDR-AD002` with `C2-CLOUDFLARE`.
- The replacement does not satisfy the default lexical-routing patterns, making the documented behavior inaccurate.

<h3>Confidence Score: 4/5</h3>

The inaccurate routing example should be corrected before merging because it reverses the documented behavior of `hybrid_alpha` for that query.

Under the default patterns, `C2-CLOUDFLARE` does not trigger lexical routing, so auto search uses the hybrid pipeline despite the README claiming otherwise.

**Files Needing Attention:** README.md

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Replaces a valid lexical-routing example with an identifier that the default QueryRouter classifies as semantic. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0AREADME.md%3A421%0A**Lexical%20routing%20example%20is%20invalid**%0A%0AWhen%20%60C2-CLOUDFLARE%60%20is%20submitted%20with%20%60search_method%3D%22auto%22%60%2C%20it%20matches%20none%20of%20the%20default%20lexical%20patterns%20and%20is%20classified%20as%20semantic%2C%20so%20the%20hybrid%20pipeline%20consults%20%60hybrid_alpha%60%20despite%20the%20README%20claiming%20that%20the%20FTS5%20fast%20path%20fires.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=lyonzin%2Fknowledge-rag&pr=171&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
README.md:421
**Lexical routing example is invalid**

When `C2-CLOUDFLARE` is submitted with `search_method="auto"`, it matches none of the default lexical patterns and is classified as semantic, so the hybrid pipeline consults `hybrid_alpha` despite the README claiming that the FTS5 fast path fires.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update README.md"](https://github.com/lyonzin/knowledge-rag/commit/34b488d77a2197ede394c8002cf4555826d15083) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52036363)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->