### PR TITLE
fix(ci): guard optional hypothesis import in test_query_router (nightly chaos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1485,6 +1485,7 @@ Common issues:
 
 ### Unreleased
 
+- **fix(ci)**: the nightly chaos job (`pytest -m chaos`) aborted collection with `ModuleNotFoundError: No module named 'hypothesis'` because `tests/test_query_router.py` imported hypothesis at module top-level while the chaos job installs only `pytest psutil numpy`. Guarded the import with `pytest.importorskip("hypothesis")` so the module is skipped cleanly instead of failing the whole nightly run (#164).
 - **docs(architecture)**: sync the 4 Mermaid diagrams in `## Architecture` (System Overview, Query Processing Flow, Document Ingestion Flow, hybrid_alpha Parameter Effect) with the v4.8.2 FTS5 fast-path (ADR-002/003/006), the v4.8.3 `_write_collection` staging dispatcher (#161), and the current 8-category layout. The diagrams previously described only the pre-v4.8 hybrid pipeline and 4-category storage; they now also show FTS5 dispatch, fallback semantics, FTS5 CRUD sync (ADR-008), and the zero-downtime staging write path. `hybrid_alpha` now clarifies that the fast-path bypasses RRF entirely so the weighting only matters on the hybrid path.
 
 ### v4.8.3 (2026-08-10) — Critical hotfix: nuclear-rebuild + smart-reindex hardening

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -9,6 +9,13 @@ import re
 from unittest.mock import MagicMock
 
 import pytest
+
+# hypothesis is an optional test dependency: some CI jobs (e.g. the nightly
+# chaos suite) install only a minimal set and run `pytest -m <marker>`, which
+# still collects the whole tests/ tree. importorskip lets pytest skip this
+# module cleanly instead of aborting collection with a ModuleNotFoundError.
+pytest.importorskip("hypothesis")
+
 from hypothesis import given, settings
 from hypothesis import strategies as st
 


### PR DESCRIPTION
## Problem

The nightly **Chaos suite** has failed four nights running (2026-08-09 → 08-12, #164). The issue text guessed "flake or threshold", but the real cause is a collection error:

```
ERROR collecting tests/test_query_router.py
tests/test_query_router.py:12: from hypothesis import given, settings
E   ModuleNotFoundError: No module named 'hypothesis'
!!!! Interrupted: 1 error during collection !!!!  → exit code 2
```

The chaos job runs `pytest -m chaos`, which still **collects the whole `tests/` tree** before filtering by marker. `test_query_router.py` imports `hypothesis` at module top-level, but the chaos job installs only `pytest psutil numpy` (the determinism and mutmut jobs install `hypothesis`, which is why they pass; soak passes because it runs a specific path, not the whole tree). Collection aborts before any chaos test runs.

## Fix

Guard the import with `pytest.importorskip("hypothesis")` so the module is skipped cleanly when hypothesis is absent, instead of aborting collection of the entire suite. This is defensive at the test level — any future job that runs `pytest` without hypothesis is protected, not just chaos.

## Validation (run locally)

Reproduced the CI runner by making `hypothesis` unimportable:

- **Before:** `pytest -m chaos` → `ModuleNotFoundError` → `1 error during collection` (matches CI exactly).
- **After:** importing the module raises `Skipped: could not import 'hypothesis'` → pytest skips the module, collection survives.
- **Sanity (hypothesis present):** `pytest -m chaos --co` collects `5/701`, exit 0 — normal path unchanged.

## 7-Pillar checklist

- [x] Pilar 2 (Estabilidade): no test deleted; one module gains a conditional skip
- [x] Pilar 6 (Versionamento): conventional commit + CHANGELOG entry under `## Unreleased`
- [x] Pilar 7 (Qualidade): minimal, documented change (why-comment explains the CI context)
- [x] Backwards compat (LEI 1): no public API change

Closes #164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Nightly chaos testing now skips cleanly when the optional Hypothesis package is unavailable, preventing test collection failures.

- **Documentation**
  - Added an Unreleased changelog entry documenting the CI improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->