### PR TITLE
fix(test): unblock release.yml — mock uvicorn.run in bearer no-token test

### DIFF
--- a/tests/security/test_bearer_auth.py
+++ b/tests/security/test_bearer_auth.py
@@ -269,20 +269,34 @@ def test_stdio_transport_bypasses_auth(monkeypatch):
     assert ran["transport"] == "stdio"
 
 
-@pytest.mark.xfail(
-    reason="integration with MCP tools pending v4.6.0 (library shipped standalone in v4.5.1)", strict=False
-)
 def test_http_transport_without_token_warns_and_stays_open(monkeypatch, capsys):
-    """Backwards compatibility: unset token keeps the current behaviour."""
+    """Backwards compatibility: unset token keeps the current warn-then-serve behaviour.
+
+    v4.8.5: HealthMiddleware is now wired in front of the app on both auth
+    branches, and uvicorn.run replaces mcp.run for HTTP transports so
+    /health probes can be served without auth. The test therefore mocks
+    uvicorn.run AND the app factory to avoid a real bind that would hang
+    the test process indefinitely (regression caught in release.yml).
+    """
     from mcp_server import server as server_module
 
     monkeypatch.setattr(server_module.config, "auth_bearer_token", "")
-    ran = {}
-    monkeypatch.setattr(server_module.mcp, "run", lambda transport: ran.setdefault("transport", transport))
+    monkeypatch.setattr(server_module.mcp, "streamable_http_app", lambda **kwargs: _SpyApp())
+    monkeypatch.setattr(
+        server_module.mcp,
+        "run",
+        lambda **kw: pytest.fail("mcp.run must not be called on the HTTP path (v4.8.5+)"),
+    )
+
+    served: dict = {}
+    monkeypatch.setattr("uvicorn.run", lambda app, **kwargs: served.update(app=app, **kwargs))
 
     server_module._run_transport("streamable-http")
 
-    assert ran["transport"] == "streamable-http"
+    # v4.8.5: the served app is HealthMiddleware(app) when token is empty.
+    from mcp_server.health import HealthMiddleware
+
+    assert isinstance(served["app"], HealthMiddleware)
     assert "Bearer auth disabled" in capsys.readouterr().err
 
 


### PR DESCRIPTION
release.yml Pre-release Tests hung for 60+ min at 4% waiting for uvicorn.run to bind on port 8179. Root cause: v4.8.5 refactor changed _run_transport to always use uvicorn.run (wrapped in HealthMiddleware); the existing test only mocked mcp.run. Now also mocks uvicorn.run + the app factory. Removes leftover xfail marker from v4.5.1.