### PR TITLE
chore(ci): ignore 3 new chromadb 1.5.9 CVEs in pip-audit

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -93,9 +93,9 @@ jobs:
           # Strict mode fails on any unfixed advisory. Documented exceptions:
           #   CVE-2026-3219 (pip): tarball symlink TOCTOU — no upstream fix
           #     as of 2026-05. Does not affect us; users run pip themselves.
-          #   CVE-2026-45829 (chromadb 1.5.9): no fix available as of 2026-06.
-          #     Upstream issue; 1.5.9 is latest. Remove when chromadb patches.
-          ignore_args="--ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-45829"
+          #   CVE-2026-45829/45830/45831/45833 (chromadb 1.5.9): no fix
+          #     available as of 2026-09. 1.5.9 is latest. Remove when patched.
+          ignore_args="--ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-45829 --ignore-vuln CVE-2026-45830 --ignore-vuln CVE-2026-45831 --ignore-vuln CVE-2026-45833"
           if [ -n "${IGNORE_AUDIT_IDS:-}" ]; then
             for id in ${IGNORE_AUDIT_IDS}; do
               ignore_args="${ignore_args} --ignore-vuln ${id}"


### PR DESCRIPTION
## Summary

- Add CVE-2026-45830, CVE-2026-45831, CVE-2026-45833 to pip-audit ignore list
- All 3 are in chromadb 1.5.9 (latest) — no upstream fix available
- Blocking every PR's Quality Gate since chromadb published the advisories
- Remove ignores when chromadb ships a patched release

## Test plan

- [ ] pip-audit step passes in Quality Gate
- [ ] No functional code changes — CI config only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency-audit exclusions for four reported vulnerabilities affecting the ChromaDB package.
  * Replaced the previous single-vulnerability exception with the updated set of audit exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the existing temporary `pip-audit` exception list for chromadb 1.5.9 while documenting that the exceptions should be removed after an upstream fix.
- Ignores CVE-2026-45830, CVE-2026-45831, and CVE-2026-45833.
- Retains strict auditing for all other unfixed advisories.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only extends the documented audit exception list and no concrete reachable failure was identified.

The workflow continues running pip-audit in strict mode while exempting only the explicitly listed chromadb advisories that the PR describes as currently lacking upstream fixes.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/quality-gate.yml | Adds three documented chromadb advisory IDs to the existing pip-audit ignore arguments; no concrete changed-code failure was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): ignore 3 new chromadb 1.5.9 C..."](https://github.com/lyonzin/knowledge-rag/commit/1635731f5d6f85208a7aa21cd708a823633fe216) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60231828)</sub>

<!-- /greptile_comment -->